### PR TITLE
fix: use synchronous transformer when no components

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ function bindNode(node: ComponentNode, data: Record<string, any>) {
   nodeData.hProperties = bindData(
     {
       ...node.attributes,
-      // parse data slots and retrive data
+      // Parse data slots and retrieve data
       ...getNodeData(node)
     },
     data


### PR DESCRIPTION
- Use synchronous transformer when components array is empty (i.e. no promises to await)

Needed to use `@docus/remark-mdc` in Docus Cloud App for Milkdown editor, beacause Milkdown doesn't support asynchronous transformers.