### PR TITLE
fix: add indexStack to toMarkdown context

### DIFF
--- a/src/to-markdown.ts
+++ b/src/to-markdown.ts
@@ -129,7 +129,7 @@ function attributes(node: Parent, context: any) {
 
 function content(node: Parent, context: any) {
   const content = inlineComponentLabel(node) ? Object.assign({}, node, { children: node.children.slice(1) }) : node
-
+  context.indexStack = context.stack
   return containerFlow(content, context)
 }
 


### PR DESCRIPTION
Fixes #17 