### PR TITLE
fix(span): ignore double brackets

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "remark-gfm": "^3.0.1",
     "remark-parse": "^10.0.1",
     "remark-stringify": "^10.0.2",
+    "remark-wiki-link": "^1.0.4",
     "standard-version": "^9.3.2",
     "unbuild": "^0.7.0",
     "vitest": "latest"

--- a/test/__snapshots__/span.test.ts.snap
+++ b/test/__snapshots__/span.test.ts.snap
@@ -137,7 +137,113 @@ exports[`span > [x] 1`] = `
 }
 `;
 
-exports[`span > inside-link 1`] = `
+exports[`span > ignore-double-bracket 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "position": {
+            "end": {
+              "column": 13,
+              "line": 1,
+              "offset": 12,
+            },
+            "start": {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "[[wikilink]]",
+        },
+      ],
+      "position": {
+        "end": {
+          "column": 13,
+          "line": 1,
+          "offset": 12,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 13,
+      "line": 1,
+      "offset": 12,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`span > ignored-bracket 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "position": {
+            "end": {
+              "column": 9,
+              "line": 1,
+              "offset": 8,
+            },
+            "start": {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "[label]",
+        },
+      ],
+      "position": {
+        "end": {
+          "column": 9,
+          "line": 1,
+          "offset": 8,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 9,
+      "line": 1,
+      "offset": 8,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`span > inside-link-invalid 1`] = `
 {
   "children": [
     {
@@ -145,31 +251,6 @@ exports[`span > inside-link 1`] = `
         {
           "children": [
             {
-              "attributes": {},
-              "children": [
-                {
-                  "position": {
-                    "end": {
-                      "column": 7,
-                      "line": 1,
-                      "offset": 6,
-                    },
-                    "start": {
-                      "column": 3,
-                      "line": 1,
-                      "offset": 2,
-                    },
-                  },
-                  "type": "text",
-                  "value": "span",
-                },
-              ],
-              "data": {
-                "hName": "span",
-                "hProperties": {},
-              },
-              "fmAttributes": {},
-              "name": "span",
               "position": {
                 "end": {
                   "column": 8,
@@ -182,7 +263,8 @@ exports[`span > inside-link 1`] = `
                   "offset": 1,
                 },
               },
-              "type": "textComponent",
+              "type": "text",
+              "value": "[span]",
             },
           ],
           "position": {
@@ -222,6 +304,118 @@ exports[`span > inside-link 1`] = `
       "column": 16,
       "line": 1,
       "offset": 15,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`span > inside-link-valid 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "position": {
+                "end": {
+                  "column": 3,
+                  "line": 1,
+                  "offset": 2,
+                },
+                "start": {
+                  "column": 2,
+                  "line": 1,
+                  "offset": 1,
+                },
+              },
+              "type": "text",
+              "value": " ",
+            },
+            {
+              "attributes": {},
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 8,
+                      "line": 1,
+                      "offset": 7,
+                    },
+                    "start": {
+                      "column": 4,
+                      "line": 1,
+                      "offset": 3,
+                    },
+                  },
+                  "type": "text",
+                  "value": "span",
+                },
+              ],
+              "data": {
+                "hName": "span",
+                "hProperties": {},
+              },
+              "fmAttributes": {},
+              "name": "span",
+              "position": {
+                "end": {
+                  "column": 9,
+                  "line": 1,
+                  "offset": 8,
+                },
+                "start": {
+                  "column": 3,
+                  "line": 1,
+                  "offset": 2,
+                },
+              },
+              "type": "textComponent",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 17,
+              "line": 1,
+              "offset": 16,
+            },
+            "start": {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "title": null,
+          "type": "link",
+          "url": "#href",
+        },
+      ],
+      "position": {
+        "end": {
+          "column": 17,
+          "line": 1,
+          "offset": 16,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 17,
+      "line": 1,
+      "offset": 16,
     },
     "start": {
       "column": 1,
@@ -620,6 +814,75 @@ exports[`span > with-attributes 1`] = `
       "column": 70,
       "line": 1,
       "offset": 69,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`span > with-wikilinks 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "data": {
+            "alias": "span",
+            "exists": false,
+            "hChildren": [
+              {
+                "type": "text",
+                "value": "span",
+              },
+            ],
+            "hName": "a",
+            "hProperties": {
+              "className": "internal new",
+              "href": "#/page/span",
+            },
+            "permalink": "span",
+          },
+          "position": {
+            "end": {
+              "column": 9,
+              "line": 1,
+              "offset": 8,
+            },
+            "start": {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "wikiLink",
+          "value": "span",
+        },
+      ],
+      "position": {
+        "end": {
+          "column": 9,
+          "line": 1,
+          "offset": 8,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 9,
+      "line": 1,
+      "offset": 8,
     },
     "start": {
       "column": 1,

--- a/test/span.test.ts
+++ b/test/span.test.ts
@@ -1,13 +1,48 @@
 import { describe, expect } from 'vitest'
 import { runMarkdownTests } from './utils'
 
-describe('span', () => {
+describe('span', async () => {
+  const wikiLink = await import('remark-wiki-link').then(r => r.default)
+
   runMarkdownTests({
     simple: {
       markdown: '[span]'
     },
-    'inside-link': {
-      markdown: '[[span]](#href)'
+    'inside-link-valid': {
+      markdown: '[ [span]](#href)',
+      extra (_markdown, ast, _expected) {
+        expect(ast.children[0].children[0]).toMatchObject({
+          type: 'link',
+          children: [
+            { type: 'text', value: ' ' },
+            { type: 'textComponent', name: 'span' }
+          ]
+        })
+      }
+    },
+    'inside-link-invalid': {
+      markdown: '[[span]](#href)',
+      expected: '[\\[span\\]](#href)',
+      extra (_markdown, ast, _expected) {
+        expect(ast.children[0].children[0]).toMatchObject({
+          type: 'link',
+          children: [
+            {
+              type: 'text',
+              value: '[span]'
+            }
+          ]
+        })
+      }
+    },
+    'with-wikilinks': {
+      markdown: '[[span]]',
+      plugins: [wikiLink],
+      extra (_markdown, ast, _expected) {
+        expect(ast.children[0].children[0]).toMatchObject({
+          type: 'wikiLink'
+        })
+      }
     },
     'with-attributes': {
       markdown: '[span]{#theid.aclass foo="bar" class="anotherclass" class="andother"}',
@@ -41,6 +76,22 @@ describe('span', () => {
     },
     'respect-reference-style-link': {
       markdown: '[link][ref]\n\n[ref]: http://example.com'
+    },
+    'ignore-double-bracket': {
+      markdown: '[[wikilink]]',
+      expected: '\\[\\[wikilink]]',
+      extra (_markdown, ast, _expected) {
+        expect(ast.children[0].children[0].type).toEqual('text')
+        expect(ast.children[0].children[0].value).toEqual('[[wikilink]]')
+      }
+    },
+    'ignored-bracket': {
+      markdown: '\\[label]',
+      expected: '\\[label]',
+      extra (_markdown, ast, _expected) {
+        expect(ast.children[0].children[0].type).toEqual('text')
+        expect(ast.children[0].children[0].value).toEqual('[label]')
+      }
     }
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -405,6 +405,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.4.4":
+  version: 7.18.9
+  resolution: "@babel/runtime@npm:7.18.9"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: 36dd736baba7164e82b3cc9d43e081f0cb2d05ff867ad39cac515d99546cee75b7f782018b02a3dcf5f2ef3d27f319faa68965fdfec49d4912c60c6002353a2e
+  languageName: node
+  linkType: hard
+
 "@babel/standalone@npm:^7.17.7":
   version: 7.18.7
   resolution: "@babel/standalone@npm:7.18.7"
@@ -2111,6 +2120,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"character-entities-legacy@npm:^1.0.0":
+  version: 1.1.4
+  resolution: "character-entities-legacy@npm:1.1.4"
+  checksum: fe03a82c154414da3a0c8ab3188e4237ec68006cbcd681cf23c7cfb9502a0e76cd30ab69a2e50857ca10d984d57de3b307680fff5328ccd427f400e559c3a811
+  languageName: node
+  linkType: hard
+
 "character-entities-legacy@npm:^3.0.0":
   version: 3.0.0
   resolution: "character-entities-legacy@npm:3.0.0"
@@ -2118,10 +2134,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"character-entities@npm:^1.0.0":
+  version: 1.2.4
+  resolution: "character-entities@npm:1.2.4"
+  checksum: e1545716571ead57beac008433c1ff69517cd8ca5b336889321c5b8ff4a99c29b65589a701e9c086cda8a5e346a67295e2684f6c7ea96819fe85cbf49bf8686d
+  languageName: node
+  linkType: hard
+
 "character-entities@npm:^2.0.0":
   version: 2.0.1
   resolution: "character-entities@npm:2.0.1"
   checksum: 1165064dbe1cc1f3cd5b28eba0e94f051d97bdd65463b0e763d6a8aae527443596f9e0e774a79c4a66de0c47ad95c94fc5fb2c7f6bec6551b5580f730a8da341
+  languageName: node
+  linkType: hard
+
+"character-reference-invalid@npm:^1.0.0":
+  version: 1.1.4
+  resolution: "character-reference-invalid@npm:1.1.4"
+  checksum: 20274574c70e05e2f81135f3b93285536bc8ff70f37f0809b0d17791a832838f1e49938382899ed4cb444e5bbd4314ca1415231344ba29f4222ce2ccf24fea0b
   languageName: node
   linkType: hard
 
@@ -5309,10 +5339,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-alphabetical@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "is-alphabetical@npm:1.0.4"
+  checksum: 6508cce44fd348f06705d377b260974f4ce68c74000e7da4045f0d919e568226dc3ce9685c5a2af272195384df6930f748ce9213fc9f399b5d31b362c66312cb
+  languageName: node
+  linkType: hard
+
 "is-alphabetical@npm:^2.0.0":
   version: 2.0.1
   resolution: "is-alphabetical@npm:2.0.1"
   checksum: 56207db8d9de0850f0cd30f4966bf731eb82cedfe496cbc2e97e7c3bacaf66fc54a972d2d08c0d93bb679cb84976a05d24c5ad63de56fabbfc60aadae312edaa
+  languageName: node
+  linkType: hard
+
+"is-alphanumerical@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "is-alphanumerical@npm:1.0.4"
+  dependencies:
+    is-alphabetical: ^1.0.0
+    is-decimal: ^1.0.0
+  checksum: e2e491acc16fcf5b363f7c726f666a9538dba0a043665740feb45bba1652457a73441e7c5179c6768a638ed396db3437e9905f403644ec7c468fb41f4813d03f
   languageName: node
   linkType: hard
 
@@ -5402,6 +5449,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-decimal@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "is-decimal@npm:1.0.4"
+  checksum: ed483a387517856dc395c68403a10201fddcc1b63dc56513fbe2fe86ab38766120090ecdbfed89223d84ca8b1cd28b0641b93cb6597b6e8f4c097a7c24e3fb96
+  languageName: node
+  linkType: hard
+
 "is-decimal@npm:^2.0.0":
   version: 2.0.1
   resolution: "is-decimal@npm:2.0.1"
@@ -5447,6 +5501,13 @@ __metadata:
   dependencies:
     is-extglob: ^2.1.1
   checksum: d381c1319fcb69d341cc6e6c7cd588e17cd94722d9a32dbd60660b993c4fb7d0f19438674e68dfec686d09b7c73139c9166b47597f846af387450224a8101ab4
+  languageName: node
+  linkType: hard
+
+"is-hexadecimal@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "is-hexadecimal@npm:1.0.4"
+  checksum: a452e047587b6069332d83130f54d30da4faf2f2ebaa2ce6d073c27b5703d030d58ed9e0b729c8e4e5b52c6f1dab26781bb77b7bc6c7805f14f320e328ff8cd5
   languageName: node
   linkType: hard
 
@@ -6077,6 +6138,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"longest-streak@npm:^2.0.0":
+  version: 2.0.4
+  resolution: "longest-streak@npm:2.0.4"
+  checksum: 28b8234a14963002c5c71035dee13a0a11e9e9d18ffa320fdc8796ed7437399204495702ed69cd2a7087b0af041a2a8b562829b7c1e2042e73a3374d1ecf6580
+  languageName: node
+  linkType: hard
+
 "longest-streak@npm:^3.0.0":
   version: 3.0.1
   resolution: "longest-streak@npm:3.0.1"
@@ -6287,6 +6355,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-to-markdown@npm:^0.6.5":
+  version: 0.6.5
+  resolution: "mdast-util-to-markdown@npm:0.6.5"
+  dependencies:
+    "@types/unist": ^2.0.0
+    longest-streak: ^2.0.0
+    mdast-util-to-string: ^2.0.0
+    parse-entities: ^2.0.0
+    repeat-string: ^1.0.0
+    zwitch: ^1.0.0
+  checksum: 7ebc47533bff6e8669f85ae124dc521ea570e9df41c0d9e4f0f43c19ef4a8c9928d741f3e4afa62fcca1927479b714582ff5fd684ef240d84ee5b75ab9d863cf
+  languageName: node
+  linkType: hard
+
 "mdast-util-to-markdown@npm:^1.0.0, mdast-util-to-markdown@npm:^1.3.0":
   version: 1.3.0
   resolution: "mdast-util-to-markdown@npm:1.3.0"
@@ -6302,10 +6384,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-to-string@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdast-util-to-string@npm:2.0.0"
+  checksum: 0b2113ada10e002fbccb014170506dabe2f2ddacaacbe4bc1045c33f986652c5a162732a2c057c5335cdb58419e2ad23e368e5be226855d4d4e280b81c4e9ec2
+  languageName: node
+  linkType: hard
+
 "mdast-util-to-string@npm:^3.0.0, mdast-util-to-string@npm:^3.1.0":
   version: 3.1.0
   resolution: "mdast-util-to-string@npm:3.1.0"
   checksum: f42ddd4e22f2215a75715b92ea6e3149c4ba356e7781d7b94fc86ded1c79cec3f986afeecef3a4a80068c9b224a6520099783a12146b957de24f020a3e47dd29
+  languageName: node
+  linkType: hard
+
+"mdast-util-wiki-link@npm:^0.0.2":
+  version: 0.0.2
+  resolution: "mdast-util-wiki-link@npm:0.0.2"
+  dependencies:
+    "@babel/runtime": ^7.12.1
+    mdast-util-to-markdown: ^0.6.5
+  checksum: a710a8ac72dceb01c0cbfee4ac3c1272c82bb526f2ee04a4415385afed88f73e449833ab288048e5e6bb8947a4eb2f4f6fa98e8fd41809cdfaae2fa6321c176a
   languageName: node
   linkType: hard
 
@@ -6473,6 +6572,15 @@ __metadata:
     micromark-util-combine-extensions: ^1.0.0
     micromark-util-types: ^1.0.0
   checksum: b181479c87be38d5ae8d28e6dc52fab73c894fd2706876746f27a91fb186644ce03532a9c35dca2186327a0e2285cd5242ad0361dc89adedd4a50376ffd94e22
+  languageName: node
+  linkType: hard
+
+"micromark-extension-wiki-link@npm:^0.0.4":
+  version: 0.0.4
+  resolution: "micromark-extension-wiki-link@npm:0.0.4"
+  dependencies:
+    "@babel/runtime": ^7.12.1
+  checksum: 39d40bec66d787d5015b31a43c5261a0a73d7108d33c5447dbac4e7f7d6ca435f547cc4596d95db820dc6ab5b930f06b77c9795d4365fdfadc8f7d056d3cb6e4
   languageName: node
   linkType: hard
 
@@ -7587,6 +7695,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse-entities@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "parse-entities@npm:2.0.0"
+  dependencies:
+    character-entities: ^1.0.0
+    character-entities-legacy: ^1.0.0
+    character-reference-invalid: ^1.0.0
+    is-alphanumerical: ^1.0.0
+    is-decimal: ^1.0.0
+    is-hexadecimal: ^1.0.0
+  checksum: 7addfd3e7d747521afac33c8121a5f23043c6973809756920d37e806639b4898385d386fcf4b3c8e2ecf1bc28aac5ae97df0b112d5042034efbe80f44081ebce
+  languageName: node
+  linkType: hard
+
 "parse-entities@npm:^4.0.0":
   version: 4.0.0
   resolution: "parse-entities@npm:4.0.0"
@@ -8456,6 +8578,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regenerator-runtime@npm:^0.13.4":
+  version: 0.13.9
+  resolution: "regenerator-runtime@npm:0.13.9"
+  checksum: 65ed455fe5afd799e2897baf691ca21c2772e1a969d19bb0c4695757c2d96249eb74ee3553ea34a91062b2a676beedf630b4c1551cc6299afb937be1426ec55e
+  languageName: node
+  linkType: hard
+
 "regexp-tree@npm:^0.1.24, regexp-tree@npm:~0.1.1":
   version: 0.1.24
   resolution: "regexp-tree@npm:0.1.24"
@@ -8509,6 +8638,7 @@ __metadata:
     remark-gfm: ^3.0.1
     remark-parse: ^10.0.1
     remark-stringify: ^10.0.2
+    remark-wiki-link: ^1.0.4
     scule: ^0.2.1
     standard-version: ^9.3.2
     stringify-entities: ^4.0.2
@@ -8538,6 +8668,24 @@ __metadata:
     mdast-util-to-markdown: ^1.0.0
     unified: ^10.0.0
   checksum: 25424201e698353f6c0afc9ec29a8cac1dac8c06750d92214e3216bd76ac37902a0ba3702ac2a11c1040938a667b3bc22d6949af1d35e8fc81a3572643cdc263
+  languageName: node
+  linkType: hard
+
+"remark-wiki-link@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "remark-wiki-link@npm:1.0.4"
+  dependencies:
+    "@babel/runtime": ^7.4.4
+    mdast-util-wiki-link: ^0.0.2
+    micromark-extension-wiki-link: ^0.0.4
+  checksum: 8d2e2f33c49b3660dc97c0974b4475b00ff9465e2c3240b24cbb4249e42e3b724d67b89f85b4beb9d872066e6c72371b9dc18326e212de211e3313f18892e873
+  languageName: node
+  linkType: hard
+
+"repeat-string@npm:^1.0.0":
+  version: 1.6.1
+  resolution: "repeat-string@npm:1.6.1"
+  checksum: 1b809fc6db97decdc68f5b12c4d1a671c8e3f65ec4a40c238bc5200e44e85bcc52a54f78268ab9c29fcf5fe4f1343e805420056d1f30fa9a9ee4c2d93e3cc6c0
   languageName: node
   linkType: hard
 
@@ -10574,6 +10722,13 @@ __metadata:
     compress-commons: ^4.1.0
     readable-stream: ^3.6.0
   checksum: 4a73da856738b0634700b52f4ab3fe0bf0a532bea6820ad962d0bda0163d2d5525df4859f89a7238e204a378384e12551985049790c1894c3ac191866e85887f
+  languageName: node
+  linkType: hard
+
+"zwitch@npm:^1.0.0":
+  version: 1.0.5
+  resolution: "zwitch@npm:1.0.5"
+  checksum: 28a1bebacab3bc60150b6b0a2ba1db2ad033f068e81f05e4892ec0ea13ae63f5d140a1d692062ac0657840c8da076f35b94433b5f1c329d7803b247de80f064a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR will ignore double brackets from span syntax and make MDC compatible with wikilinks.

This also is a minor breaking change, `[[span]](/link)` will not detect as a span component. This is the exact behavior of wikilinks.

resolves https://github.com/nuxt/content/issues/1445