### PR TITLE
feat: sugar syntax for blocks

### DIFF
--- a/src/micromark-extension/index.ts
+++ b/src/micromark-extension/index.ts
@@ -11,6 +11,7 @@ import tokenizeInline from './tokenize-inline'
 import tokenizeContainer from './tokenize-container'
 import tokenizeContainerIndented from './tokenize-container-indented'
 import { Codes } from './constants'
+import tokenizeContainerSuger from './tokenize-container-suger'
 
 export default function micromarkComponentsExtension () {
   return {
@@ -20,7 +21,7 @@ export default function micromarkComponentsExtension () {
       [Codes.openingCurlyBracket]: [tokenizeBinding, tokenizeAttribute]
     },
     flow: {
-      [Codes.colon]: [tokenizeContainer]
+      [Codes.colon]: [tokenizeContainer, tokenizeContainerSuger]
     },
     flowInitial: {
       '-2': tokenizeContainerIndented,

--- a/src/micromark-extension/tokenize-container-suger.ts
+++ b/src/micromark-extension/tokenize-container-suger.ts
@@ -1,0 +1,45 @@
+import type { Effects, State, TokenizeContext, Code } from 'micromark-util-types'
+import { markdownLineEnding } from 'micromark-util-character'
+import { factorySpace } from 'micromark-factory-space'
+import componentContainer from './tokenize-inline'
+import { Codes } from './constants'
+
+/**
+
+text
+
+:component
+
+text
+
+ */
+function tokenize (this: TokenizeContext, effects: Effects, ok: State, nok: State) {
+  const self = this
+
+  const tokenizeSugerSyntax = componentContainer.tokenize.call(
+    self,
+    effects,
+    factorySpace(effects, exit as State, 'linePrefix'),
+    nok
+  )
+
+  return factorySpace(effects, lineStart as State, 'linePrefix')
+
+  function lineStart (code: Code): void | State {
+    if (code === Codes.colon) {
+      return tokenizeSugerSyntax(code)
+    }
+    return nok(code)
+  }
+
+  function exit (code: Code): void | State {
+    if (markdownLineEnding(code) || code === Codes.EOF) {
+      return ok(code)
+    }
+    return nok(code)
+  }
+}
+
+export default {
+  tokenize
+}

--- a/test/__snapshots__/attributes.test.ts.snap
+++ b/test/__snapshots__/attributes.test.ts.snap
@@ -32,12 +32,28 @@ exports[`Attributes > boolean 1`] = `
           },
           "type": "textComponent",
         },
+        {
+          "position": {
+            "end": {
+              "column": 17,
+              "line": 1,
+              "offset": 16,
+            },
+            "start": {
+              "column": 12,
+              "line": 1,
+              "offset": 11,
+            },
+          },
+          "type": "text",
+          "value": " text",
+        },
       ],
       "position": {
         "end": {
-          "column": 12,
+          "column": 17,
           "line": 1,
-          "offset": 11,
+          "offset": 16,
         },
         "start": {
           "column": 1,
@@ -50,9 +66,9 @@ exports[`Attributes > boolean 1`] = `
   ],
   "position": {
     "end": {
-      "column": 12,
+      "column": 17,
       "line": 1,
-      "offset": 11,
+      "offset": 16,
     },
     "start": {
       "column": 1,
@@ -98,12 +114,28 @@ exports[`Attributes > class-suger 1`] = `
           },
           "type": "textComponent",
         },
+        {
+          "position": {
+            "end": {
+              "column": 46,
+              "line": 1,
+              "offset": 45,
+            },
+            "start": {
+              "column": 41,
+              "line": 1,
+              "offset": 40,
+            },
+          },
+          "type": "text",
+          "value": " text",
+        },
       ],
       "position": {
         "end": {
-          "column": 41,
+          "column": 46,
           "line": 1,
-          "offset": 40,
+          "offset": 45,
         },
         "start": {
           "column": 1,
@@ -116,9 +148,9 @@ exports[`Attributes > class-suger 1`] = `
   ],
   "position": {
     "end": {
-      "column": 41,
+      "column": 46,
       "line": 1,
-      "offset": 40,
+      "offset": 45,
     },
     "start": {
       "column": 1,
@@ -373,12 +405,28 @@ exports[`Attributes > html-characters 1`] = `
           },
           "type": "textComponent",
         },
+        {
+          "position": {
+            "end": {
+              "column": 26,
+              "line": 1,
+              "offset": 25,
+            },
+            "start": {
+              "column": 21,
+              "line": 1,
+              "offset": 20,
+            },
+          },
+          "type": "text",
+          "value": " text",
+        },
       ],
       "position": {
         "end": {
-          "column": 21,
+          "column": 26,
           "line": 1,
-          "offset": 20,
+          "offset": 25,
         },
         "start": {
           "column": 1,
@@ -391,9 +439,9 @@ exports[`Attributes > html-characters 1`] = `
   ],
   "position": {
     "end": {
-      "column": 21,
+      "column": 26,
       "line": 1,
-      "offset": 20,
+      "offset": 25,
     },
     "start": {
       "column": 1,
@@ -437,12 +485,28 @@ exports[`Attributes > html-characters-unquoted 1`] = `
           },
           "type": "textComponent",
         },
+        {
+          "position": {
+            "end": {
+              "column": 24,
+              "line": 1,
+              "offset": 23,
+            },
+            "start": {
+              "column": 19,
+              "line": 1,
+              "offset": 18,
+            },
+          },
+          "type": "text",
+          "value": " text",
+        },
       ],
       "position": {
         "end": {
-          "column": 19,
+          "column": 24,
           "line": 1,
-          "offset": 18,
+          "offset": 23,
         },
         "start": {
           "column": 1,
@@ -455,9 +519,9 @@ exports[`Attributes > html-characters-unquoted 1`] = `
   ],
   "position": {
     "end": {
-      "column": 19,
+      "column": 24,
       "line": 1,
-      "offset": 18,
+      "offset": 23,
     },
     "start": {
       "column": 1,
@@ -501,12 +565,28 @@ exports[`Attributes > id-suger 1`] = `
           },
           "type": "textComponent",
         },
+        {
+          "position": {
+            "end": {
+              "column": 16,
+              "line": 1,
+              "offset": 15,
+            },
+            "start": {
+              "column": 11,
+              "line": 1,
+              "offset": 10,
+            },
+          },
+          "type": "text",
+          "value": " text",
+        },
       ],
       "position": {
         "end": {
-          "column": 11,
+          "column": 16,
           "line": 1,
-          "offset": 10,
+          "offset": 15,
         },
         "start": {
           "column": 1,
@@ -519,9 +599,9 @@ exports[`Attributes > id-suger 1`] = `
   ],
   "position": {
     "end": {
-      "column": 11,
+      "column": 16,
       "line": 1,
-      "offset": 10,
+      "offset": 15,
     },
     "start": {
       "column": 1,
@@ -623,9 +703,9 @@ exports[`Attributes > invlid-binding 1`] = `
         {
           "position": {
             "end": {
-              "column": 9,
+              "column": 14,
               "line": 1,
-              "offset": 8,
+              "offset": 13,
             },
             "start": {
               "column": 6,
@@ -634,14 +714,14 @@ exports[`Attributes > invlid-binding 1`] = `
             },
           },
           "type": "text",
-          "value": "{:}",
+          "value": "{:} text",
         },
       ],
       "position": {
         "end": {
-          "column": 9,
+          "column": 14,
           "line": 1,
-          "offset": 8,
+          "offset": 13,
         },
         "start": {
           "column": 1,
@@ -654,9 +734,9 @@ exports[`Attributes > invlid-binding 1`] = `
   ],
   "position": {
     "end": {
-      "column": 9,
+      "column": 14,
       "line": 1,
-      "offset": 8,
+      "offset": 13,
     },
     "start": {
       "column": 1,
@@ -850,12 +930,28 @@ exports[`Attributes > value-with-space 1`] = `
           },
           "type": "textComponent",
         },
+        {
+          "position": {
+            "end": {
+              "column": 24,
+              "line": 1,
+              "offset": 23,
+            },
+            "start": {
+              "column": 19,
+              "line": 1,
+              "offset": 18,
+            },
+          },
+          "type": "text",
+          "value": " text",
+        },
       ],
       "position": {
         "end": {
-          "column": 19,
+          "column": 24,
           "line": 1,
-          "offset": 18,
+          "offset": 23,
         },
         "start": {
           "column": 1,
@@ -868,9 +964,9 @@ exports[`Attributes > value-with-space 1`] = `
   ],
   "position": {
     "end": {
-      "column": 19,
+      "column": 24,
       "line": 1,
-      "offset": 18,
+      "offset": 23,
     },
     "start": {
       "column": 1,

--- a/test/__snapshots__/block-component.test.ts.snap
+++ b/test/__snapshots__/block-component.test.ts.snap
@@ -1321,6 +1321,49 @@ exports[`block-component > section-order-2 1`] = `
 }
 `;
 
+exports[`block-component > sugar-syntax 1`] = `
+{
+  "children": [
+    {
+      "attributes": {},
+      "children": [],
+      "data": {
+        "hName": "component",
+        "hProperties": {},
+      },
+      "fmAttributes": {},
+      "name": "component",
+      "position": {
+        "end": {
+          "column": 11,
+          "line": 1,
+          "offset": 10,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "textComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 11,
+      "line": 1,
+      "offset": 10,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
 exports[`block-component > text 1`] = `
 {
   "children": [

--- a/test/__snapshots__/inline-component.test.ts.snap
+++ b/test/__snapshots__/inline-component.test.ts.snap
@@ -28,12 +28,28 @@ exports[`inline-component > empty 1`] = `
           },
           "type": "textComponent",
         },
+        {
+          "position": {
+            "end": {
+              "column": 16,
+              "line": 1,
+              "offset": 15,
+            },
+            "start": {
+              "column": 11,
+              "line": 1,
+              "offset": 10,
+            },
+          },
+          "type": "text",
+          "value": " text",
+        },
       ],
       "position": {
         "end": {
-          "column": 11,
+          "column": 16,
           "line": 1,
-          "offset": 10,
+          "offset": 15,
         },
         "start": {
           "column": 1,
@@ -46,9 +62,9 @@ exports[`inline-component > empty 1`] = `
   ],
   "position": {
     "end": {
-      "column": 11,
+      "column": 16,
       "line": 1,
-      "offset": 10,
+      "offset": 15,
     },
     "start": {
       "column": 1,
@@ -203,12 +219,28 @@ exports[`inline-component > text 1`] = `
           },
           "type": "textComponent",
         },
+        {
+          "position": {
+            "end": {
+              "column": 22,
+              "line": 1,
+              "offset": 21,
+            },
+            "start": {
+              "column": 17,
+              "line": 1,
+              "offset": 16,
+            },
+          },
+          "type": "text",
+          "value": " text",
+        },
       ],
       "position": {
         "end": {
-          "column": 17,
+          "column": 22,
           "line": 1,
-          "offset": 16,
+          "offset": 21,
         },
         "start": {
           "column": 1,
@@ -221,9 +253,9 @@ exports[`inline-component > text 1`] = `
   ],
   "position": {
     "end": {
-      "column": 17,
+      "column": 22,
       "line": 1,
-      "offset": 16,
+      "offset": 21,
     },
     "start": {
       "column": 1,
@@ -382,12 +414,28 @@ exports[`inline-component > with-attribute 1`] = `
           },
           "type": "textComponent",
         },
+        {
+          "position": {
+            "end": {
+              "column": 30,
+              "line": 1,
+              "offset": 29,
+            },
+            "start": {
+              "column": 25,
+              "line": 1,
+              "offset": 24,
+            },
+          },
+          "type": "text",
+          "value": " text",
+        },
       ],
       "position": {
         "end": {
-          "column": 25,
+          "column": 30,
           "line": 1,
-          "offset": 24,
+          "offset": 29,
         },
         "start": {
           "column": 1,
@@ -400,9 +448,9 @@ exports[`inline-component > with-attribute 1`] = `
   ],
   "position": {
     "end": {
-      "column": 25,
+      "column": 30,
       "line": 1,
-      "offset": 24,
+      "offset": 29,
     },
     "start": {
       "column": 1,

--- a/test/__snapshots__/label.test.ts.snap
+++ b/test/__snapshots__/label.test.ts.snap
@@ -28,12 +28,28 @@ exports[`label > empty 1`] = `
           },
           "type": "textComponent",
         },
+        {
+          "position": {
+            "end": {
+              "column": 13,
+              "line": 1,
+              "offset": 12,
+            },
+            "start": {
+              "column": 8,
+              "line": 1,
+              "offset": 7,
+            },
+          },
+          "type": "text",
+          "value": " text",
+        },
       ],
       "position": {
         "end": {
-          "column": 8,
+          "column": 13,
           "line": 1,
-          "offset": 7,
+          "offset": 12,
         },
         "start": {
           "column": 1,
@@ -46,9 +62,9 @@ exports[`label > empty 1`] = `
   ],
   "position": {
     "end": {
-      "column": 8,
+      "column": 13,
       "line": 1,
-      "offset": 7,
+      "offset": 12,
     },
     "start": {
       "column": 1,
@@ -91,9 +107,9 @@ exports[`label > invalid-label-eof 1`] = `
         {
           "position": {
             "end": {
-              "column": 7,
+              "column": 12,
               "line": 1,
-              "offset": 6,
+              "offset": 11,
             },
             "start": {
               "column": 6,
@@ -102,14 +118,14 @@ exports[`label > invalid-label-eof 1`] = `
             },
           },
           "type": "text",
-          "value": "[",
+          "value": "[ text",
         },
       ],
       "position": {
         "end": {
-          "column": 7,
+          "column": 12,
           "line": 1,
-          "offset": 6,
+          "offset": 11,
         },
         "start": {
           "column": 1,
@@ -122,9 +138,9 @@ exports[`label > invalid-label-eof 1`] = `
   ],
   "position": {
     "end": {
-      "column": 7,
+      "column": 12,
       "line": 1,
-      "offset": 6,
+      "offset": 11,
     },
     "start": {
       "column": 1,
@@ -257,12 +273,28 @@ exports[`label > scaped-characters 1`] = `
           },
           "type": "textComponent",
         },
+        {
+          "position": {
+            "end": {
+              "column": 31,
+              "line": 1,
+              "offset": 30,
+            },
+            "start": {
+              "column": 26,
+              "line": 1,
+              "offset": 25,
+            },
+          },
+          "type": "text",
+          "value": " text",
+        },
       ],
       "position": {
         "end": {
-          "column": 26,
+          "column": 31,
           "line": 1,
-          "offset": 25,
+          "offset": 30,
         },
         "start": {
           "column": 1,
@@ -275,9 +307,9 @@ exports[`label > scaped-characters 1`] = `
   ],
   "position": {
     "end": {
-      "column": 26,
+      "column": 31,
       "line": 1,
-      "offset": 25,
+      "offset": 30,
     },
     "start": {
       "column": 1,
@@ -334,12 +366,28 @@ exports[`label > simple 1`] = `
           },
           "type": "textComponent",
         },
+        {
+          "position": {
+            "end": {
+              "column": 18,
+              "line": 1,
+              "offset": 17,
+            },
+            "start": {
+              "column": 13,
+              "line": 1,
+              "offset": 12,
+            },
+          },
+          "type": "text",
+          "value": " text",
+        },
       ],
       "position": {
         "end": {
-          "column": 13,
+          "column": 18,
           "line": 1,
-          "offset": 12,
+          "offset": 17,
         },
         "start": {
           "column": 1,
@@ -352,9 +400,9 @@ exports[`label > simple 1`] = `
   ],
   "position": {
     "end": {
-      "column": 13,
+      "column": 18,
       "line": 1,
-      "offset": 12,
+      "offset": 17,
     },
     "start": {
       "column": 1,

--- a/test/attributes.test.ts
+++ b/test/attributes.test.ts
@@ -4,31 +4,31 @@ import { runMarkdownTests } from './utils'
 describe('Attributes', () => {
   runMarkdownTests({
     'id-suger': {
-      markdown: ':test{#id}'
+      markdown: ':test{#id} text'
     },
     'class-suger': {
-      markdown: ':test{.class .another-class key="value"}',
-      expected: ':test{.class.another-class key="value"}'
+      markdown: ':test{.class .another-class key="value"} text',
+      expected: ':test{.class.another-class key="value"} text'
     },
     boolean: {
-      markdown: ':test{prop}',
-      expected: ':test{prop="true"}'
+      markdown: ':test{prop} text',
+      expected: ':test{prop="true"} text'
     },
     'html-characters': {
-      markdown: ':test{icon="&copy;"}',
-      expected: ':test{icon="©"}'
+      markdown: ':test{icon="&copy;"} text',
+      expected: ':test{icon="©"} text'
     },
     'html-characters-unquoted': {
-      markdown: ':test{icon=&copy;}',
-      expected: ':test{icon="©"}'
+      markdown: ':test{icon=&copy;} text',
+      expected: ':test{icon="©"} text'
     },
     'value-with-space': {
-      markdown: ':test{attr= value}',
-      expected: ':test{attr="value"}'
+      markdown: ':test{attr= value} text',
+      expected: ':test{attr="value"} text'
     },
     'invlid-binding': {
-      markdown: ':test{:}',
-      expected: ':test{:}'
+      markdown: ':test{:} text',
+      expected: ':test{:} text'
     },
     'fragment-attribute': {
       markdown: '[![Nuxt](https://nuxtjs.org/design-kit/colored-logo.svg){.nest}](https:test){.cls}',

--- a/test/block-component.test.ts
+++ b/test/block-component.test.ts
@@ -1,4 +1,4 @@
-import { describe } from 'vitest'
+import { describe, expect } from 'vitest'
 import { runMarkdownTests } from './utils'
 
 describe('block-component', () => {
@@ -151,6 +151,15 @@ describe('block-component', () => {
         'slot content',
         '::'
       ].join('\n')
+    },
+    'sugar-syntax': {
+      markdown: [
+        ':component'
+      ].join('\n'),
+      extra: (_md, ast) => {
+        expect(ast.children[0].type).toBe('textComponent')
+        expect(ast.children[0].name).toBe('component')
+      }
     }
   })
 })

--- a/test/inline-component.test.ts
+++ b/test/inline-component.test.ts
@@ -4,13 +4,13 @@ import { runMarkdownTests } from './utils'
 describe('inline-component', () => {
   runMarkdownTests({
     empty: {
-      markdown: ':component'
+      markdown: ':component text'
     },
     text: {
-      markdown: ':component[text]'
+      markdown: ':component[text] text'
     },
     'with-attribute': {
-      markdown: ':component[text]{.class}'
+      markdown: ':component[text]{.class} text'
     },
     strong: {
       markdown: '**:component[text]{.class}**',

--- a/test/label.test.ts
+++ b/test/label.test.ts
@@ -4,22 +4,22 @@ import { runMarkdownTests } from './utils'
 describe('label', () => {
   runMarkdownTests({
     simple: {
-      markdown: ':test[label]'
+      markdown: ':test[label] text'
     },
     empty: {
-      markdown: ':test[]',
-      expected: ':test'
+      markdown: ':test[] text',
+      expected: ':test text'
     },
     'scaped-characters': {
-      markdown: ':test[scape \\[ character]'
+      markdown: ':test[scape \\[ character] text'
     },
     'invalid-label-eol': {
       markdown: ':test[\n',
       expected: ':test\\['
     },
     'invalid-label-eof': {
-      markdown: ':test[',
-      expected: ':test\\['
+      markdown: ':test[ text',
+      expected: ':test\\[ text'
     }
   })
 })


### PR DESCRIPTION
Move inline components from paragraph and treat them as block component if they use in a line without any prefix and postfix.
```
Paragraph 1 :the-inline

:the-block

Paragraph 2
```
based on nuxt/content#1586