### PR TITLE
fix(span): detect span syntax after a whitespace

### DIFF
--- a/example/nuxt.config.ts
+++ b/example/nuxt.config.ts
@@ -1,3 +1,1 @@
-import { defineNuxtConfig } from 'nuxt'
-
 export default defineNuxtConfig({})

--- a/src/micromark-extension/constants.ts
+++ b/src/micromark-extension/constants.ts
@@ -52,6 +52,10 @@ export const Codes = {
    */
   dot: 46,
   /**
+   * '/'
+   */
+  slash: 46,
+  /**
    * ':'
    */
   colon: 58,

--- a/src/micromark-extension/tokenize-span.ts
+++ b/src/micromark-extension/tokenize-span.ts
@@ -1,4 +1,4 @@
-import { markdownSpace } from 'micromark-util-character'
+import { markdownSpace, markdownLineEndingOrSpace } from 'micromark-util-character'
 import type { Effects, State, Code, TokenizeContext } from 'micromark-util-types'
 import { Codes } from './constants'
 import createLabel from './factory-label'
@@ -30,7 +30,7 @@ function tokenize (this: TokenizeContext, effects: Effects, ok: State, nok: Stat
     }
 
     // Ignore double brackets `[[`, AKA Wiki Links syntax
-    if (self.previous === Codes.openingSquareBracket) {
+    if (!markdownLineEndingOrSpace(self.previous) && self.previous !== null) {
       return nok(code)
     }
     return effects.check(doubleBracketCheck, nok, attemptLabel)(code)

--- a/test/__snapshots__/span.test.ts.snap
+++ b/test/__snapshots__/span.test.ts.snap
@@ -427,6 +427,59 @@ exports[`span > inside-link-valid 1`] = `
 }
 `;
 
+exports[`span > no-white-space 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "position": {
+            "end": {
+              "column": 41,
+              "line": 1,
+              "offset": 40,
+            },
+            "start": {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "'[publicPath]/images/[name]-[hash][ext]'",
+        },
+      ],
+      "position": {
+        "end": {
+          "column": 41,
+          "line": 1,
+          "offset": 40,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 41,
+      "line": 1,
+      "offset": 40,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
 exports[`span > respect-gfm-check-list 1`] = `
 {
   "children": [

--- a/test/span.test.ts
+++ b/test/span.test.ts
@@ -92,6 +92,14 @@ describe('span', async () => {
         expect(ast.children[0].children[0].type).toEqual('text')
         expect(ast.children[0].children[0].value).toEqual('[label]')
       }
+    },
+    'no-white-space': {
+      markdown: "'[publicPath]/images/[name]-[hash][ext]'",
+      expected: "'\\[publicPath]/images/\\[name]-\\[hash]\\[ext]'",
+      extra (_markdown, ast, _expected) {
+        expect(ast.children[0].children[0].type).toEqual('text')
+        expect(ast.children[0].children[0].value).toEqual("'[publicPath]/images/[name]-[hash][ext]'")
+      }
     }
   })
 })


### PR DESCRIPTION
reported in nuxtlabs/volta-app#1933

With this changes span syntax only detect when it comes right after a whitespace or in the beginning of the line