### PR TITLE
feat: add default value to variable binding

### DIFF
--- a/docs/content/0.index.md
+++ b/docs/content/0.index.md
@@ -229,7 +229,7 @@ title: Nuxt Architecture.
 
 ### `{{}}` Binding Variables
 
-The `{{ $doc.variable }}` syntax allows you to bind variables in your Markdown content. This is especially useful when you want to dynamically insert values into your document.
+The `{{ $doc.variable || 'defaultValue' }}` syntax allows you to bind variables in your Markdown content. This is especially useful when you want to dynamically insert values into your document.
 
 To use this syntax, simply enclose the variable name within double curly braces, like so:
 
@@ -238,7 +238,7 @@ To use this syntax, simply enclose the variable name within double curly braces,
 color: blue
 ---
 
-# The color is {{ $doc.color }}.
+# The color is {{ $doc.color || 'red' }}.
 ```
 
 ## Contributing

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -13,9 +13,9 @@
 
 <script setup lang="ts">
 const mdcOptions = ref({ experimental: { autoUnwrap: true } })
-const markdown = ref(`{{$doc.name || ok || sdqsd}}
+const markdown = ref(`# Hello World
 
-# Hello World
+{{ $doc.name || ok }}
 
 [span]
 

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -13,7 +13,9 @@
 
 <script setup lang="ts">
 const mdcOptions = ref({ experimental: { autoUnwrap: true } })
-const markdown = ref(`# Hello World
+const markdown = ref(`{{$doc.name || ok || sdqsd}}
+
+# Hello World
 
 [span]
 

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -15,7 +15,7 @@
 const mdcOptions = ref({ experimental: { autoUnwrap: true } })
 const markdown = ref(`# Hello World
 
-{{ $doc.name || ok }}
+{{ $doc.name || 'Nuxt' }}
 
 [span]
 

--- a/src/from-markdown.ts
+++ b/src/from-markdown.ts
@@ -81,14 +81,15 @@ export default (opts: RemarkMDCOptions = {}) => {
 
   // Bindings
   function enterBindingContent (this: CompileContext, token: Token) {
-    const bindingValue = this.sliceSerialize(token).split('||')
+    const regex = /([^|]*)(?:\|\|\s*'(.*)')?/
+    const values = regex.exec(this.sliceSerialize(token))
 
     this.enter({
       type: 'textComponent',
       name: 'binding',
       attributes: {
-        value: bindingValue[0].trim(),
-        defaultValue: bindingValue.length > 1 ? bindingValue[1].trim() : null
+        value: values[1].trim(),
+        defaultValue: values[2]
       }
     }, token)
   }

--- a/src/from-markdown.ts
+++ b/src/from-markdown.ts
@@ -65,11 +65,14 @@ const exit = {
 
 // Bindings
 function enterBindingContent (this: CompileContext, token: Token) {
+  const bindingValue = this.sliceSerialize(token).split('|');
+
   this.enter({
     type: 'textComponent',
     name: 'binding',
     attributes: {
-      value: this.sliceSerialize(token).trim()
+      value: bindingValue[0].trim(),
+      defaultValue: bindingValue.length > 1 ? bindingValue[1].trim() : null,
     }
   }, token)
 }

--- a/src/from-markdown.ts
+++ b/src/from-markdown.ts
@@ -65,7 +65,7 @@ const exit = {
 
 // Bindings
 function enterBindingContent (this: CompileContext, token: Token) {
-  const bindingValue = this.sliceSerialize(token).split('|');
+  const bindingValue = this.sliceSerialize(token).split('||');
 
   this.enter({
     type: 'textComponent',


### PR DESCRIPTION
It enables a convenient syntax for variable binding with default values. Now, you can use the following format in your Markdown documents: `{{ $doc.variable || 'Default Value' }}`.