### PR TITLE
Option for max attributes length

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "generate": "nuxi generate playground",
     "lint": "eslint --ext .js,.ts,.vue .",
     "test": "pnpm lint && vitest run",
+    "test:ui": "pnpm lint && vitest --ui --open=false",
     "prepack": "pnpm build",
     "release": "release-it"
   },

--- a/src/to-markdown.ts
+++ b/src/to-markdown.ts
@@ -97,7 +97,7 @@ export default (opts: RemarkMDCOptions = {}) => {
     const attributesText = attributes(node, context)
     const fmAttributes: Record<string, string> = node.fmAttributes || {}
 
-    if ((value + attributesText).length > 80 || Object.keys(fmAttributes).length > 0 || node.children?.some((child: RootContent) => child.type === 'componentContainerSection')) {
+    if ((value + attributesText).length > (opts?.maxAttributesLength || 80) || Object.keys(fmAttributes).length > 0 || node.children?.some((child: RootContent) => child.type === 'componentContainerSection')) {
       Object.assign(fmAttributes, (node as any).attributes)
     } else {
       value += attributesText

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -6,6 +6,7 @@ interface ComponentHandler {
 
 export interface RemarkMDCOptions {
   components?: ComponentHandler[]
+  maxAttributesLength?: number
   experimental?: {
     autoUnwrap?: boolean
     componentCodeBlockYamlProps?: boolean

--- a/test/__snapshots__/block-component.test.ts.snap
+++ b/test/__snapshots__/block-component.test.ts.snap
@@ -1,5 +1,240 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`block-component > component-attributes 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        "key": "value",
+      },
+      "children": [],
+      "data": {
+        "hName": "component",
+        "hProperties": {
+          "key": "value",
+        },
+      },
+      "fmAttributes": {},
+      "name": "component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 2,
+          "offset": 27,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 2,
+      "offset": 27,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block-component > component-attributes-length-80 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        "a": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      },
+      "children": [],
+      "data": {
+        "hName": "component",
+        "hProperties": {
+          "a": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        },
+      },
+      "fmAttributes": {},
+      "name": "component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 2,
+          "offset": 83,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 2,
+      "offset": 83,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block-component > component-attributes-length-81 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        "a": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      },
+      "children": [],
+      "data": {
+        "hName": "component",
+        "hProperties": {
+          "a": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        },
+      },
+      "fmAttributes": {},
+      "name": "component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 2,
+          "offset": 84,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 2,
+      "offset": 84,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block-component > component-attributes-remove-duplicate 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        "key": "value",
+      },
+      "children": [],
+      "data": {
+        "hName": "component",
+        "hProperties": {
+          "key": "value",
+        },
+      },
+      "fmAttributes": {},
+      "name": "component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 2,
+          "offset": 39,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 2,
+      "offset": 39,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block-component > component-max-attributes-length-option 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        "a": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      },
+      "children": [],
+      "data": {
+        "hName": "component",
+        "hProperties": {
+          "a": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        },
+      },
+      "fmAttributes": {},
+      "name": "component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 2,
+          "offset": 103,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 2,
+      "offset": 103,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
 exports[`block-component > dangling-list 1`] = `
 {
   "children": [

--- a/test/block-component.test.ts
+++ b/test/block-component.test.ts
@@ -15,6 +15,33 @@ describe('block-component', () => {
       markdown: '::component\n#text\n::',
       expected: '::component\n#text\n::'
     },
+    'component-attributes': {
+      markdown: '::component{key="value"}\n::'
+    },
+    'component-attributes-remove-duplicate': {
+      markdown: '::component{key="value" key="value"}\n::',
+      expected: '::component{key="value"}\n::'
+    },
+    'component-attributes-length-80': {
+      // `::component{a=""}` = 17 characters + 1 because array start at 0
+      markdown: `::component{a="${new Array(80 - 17 + 1).join('a')}"}\n::`
+    },
+    'component-attributes-length-81': {
+      markdown: `::component{a="${new Array(81 - 17 + 1).join('a')}"}\n::`,
+      expected: [
+        '::component',
+        '---',
+        `a: ${new Array(81 - 17 + 1).join('a')}`,
+        '---',
+        '::'
+      ].join('\n')
+    },
+    'component-max-attributes-length-option': {
+      mdcOptions: {
+        maxAttributesLength: 100
+      },
+      markdown: `::component{a="${new Array(100 - 17 + 1).join('a')}"}\n::`
+    },
     frontmatter: {
       markdown: '::with-frontmatter\n---\nkey: value\narray:\n  - item\n  - itemKey: value\n---\n::',
       expected: '::with-frontmatter\n---\narray:\n  - item\n  - itemKey: value\nkey: value\n---\n::'


### PR DESCRIPTION
Hi!

I added an option to define the max length of the component's attributes.
I added tests for that.
The default stays the same 80 chars.
In the nuxt config, add this option:
```js
mdcOptions: {
  maxAttributesLength: 100
},
```
I named the option `maxAttributesLength` but in fact, it's the length of the line, which include the name of the component and the decoration:
```js
`::component{key="value"}` //  = 24 chars
```
Maybe we could found a better name for this. Naming is hard.

Also, during development, maybe I found a possible issue that already exists before this merge request.
When this length is exceeded (default: 80), the attributes are converted to yaml format.
That's the point. But the `fmAttributes` are not properly filled and remains empty. You can see it in [the snapshot](https://github.com/ManUtopiK/remark-mdc/blob/maxAttributesLength/test/__snapshots__/block-component.test.ts.snap#L111).
This is not the case when we directly provide the component yaml props.
But  if the length is exceeded, we are now in yaml style, so I think the `fmAttributes` should have the props.
It needs review because I don't know if it's the normal behavior...