### PR TITLE
Check if value is an object to properly simple quote value

### DIFF
--- a/src/to-markdown.ts
+++ b/src/to-markdown.ts
@@ -172,6 +172,15 @@ export default (opts: RemarkMDCOptions = {}) => {
     return value ? '[' + value + ']' : ''
   }
 
+  const isValidJSON = (str: string) => {
+    try {
+      JSON.parse(str)
+      return true
+    } catch (e) {
+      return false
+    }
+  }
+
   function attributes (node: any, context: State) {
     const quote = checkQuote(context)
     const subset = (node.type as string) === 'textComponent' ? [quote] : [quote, '\n', '\r']
@@ -208,6 +217,8 @@ export default (opts: RemarkMDCOptions = {}) => {
           classes = classes.length ? '.' + classes.join('.') : ''
         } else if (key.startsWith(':') && value === 'true') {
           values.push(key.slice(1))
+        } else if (key.startsWith(':') && isValidJSON(value)) {
+          values.push(`${key}='${value}'`)
         } else {
           values.push(quoted(key, value))
         }

--- a/test/__snapshots__/block-component.test.ts.snap
+++ b/test/__snapshots__/block-component.test.ts.snap
@@ -1,5 +1,367 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`block-component > component-attributes-array-convert-double-quote 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        ":items": "[1,2,3.5]",
+      },
+      "children": [],
+      "data": {
+        "hName": "container-component",
+        "hProperties": {
+          ":items": "[1,2,3.5]",
+        },
+      },
+      "fmAttributes": {},
+      "name": "container-component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 2,
+          "offset": 44,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 2,
+      "offset": 44,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block-component > component-attributes-array-of-number 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        ":items": "[1,2,3.5]",
+      },
+      "children": [],
+      "data": {
+        "hName": "container-component",
+        "hProperties": {
+          ":items": "[1,2,3.5]",
+        },
+      },
+      "fmAttributes": {},
+      "name": "container-component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 2,
+          "offset": 44,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 2,
+      "offset": 44,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block-component > component-attributes-array-of-string 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        ":items": "[\\"Nuxt\\", \\"Vue\\"]",
+      },
+      "children": [],
+      "data": {
+        "hName": "container-component",
+        "hProperties": {
+          ":items": "[\\"Nuxt\\", \\"Vue\\"]",
+        },
+      },
+      "fmAttributes": {},
+      "name": "container-component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 2,
+          "offset": 50,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 2,
+      "offset": 50,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block-component > component-attributes-bad-array 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        ":items": "[Nuxt,Vue]",
+      },
+      "children": [],
+      "data": {
+        "hName": "container-component",
+        "hProperties": {
+          ":items": "[Nuxt,Vue]",
+        },
+      },
+      "fmAttributes": {},
+      "name": "container-component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 2,
+          "offset": 45,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 2,
+      "offset": 45,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block-component > component-attributes-bind-frontmatter 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        ":key": "value",
+      },
+      "children": [],
+      "data": {
+        "hName": "text-component",
+        "hProperties": {
+          ":key": "value",
+        },
+      },
+      "fmAttributes": {},
+      "name": "text-component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 2,
+          "offset": 33,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 2,
+      "offset": 33,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block-component > component-attributes-object 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        ":items": "{\\"key\\": \\"value\\"}",
+      },
+      "children": [],
+      "data": {
+        "hName": "container-component",
+        "hProperties": {
+          ":items": "{\\"key\\": \\"value\\"}",
+        },
+      },
+      "fmAttributes": {},
+      "name": "container-component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 2,
+          "offset": 51,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 2,
+      "offset": 51,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block-component > component-hProperties-be-the-same 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        ":items": "{\\"key\\":\\"value\\"}",
+      },
+      "children": [],
+      "data": {
+        "hName": "container-component",
+        "hProperties": {
+          ":items": "{\\"key\\":\\"value\\"}",
+        },
+      },
+      "fmAttributes": {},
+      "name": "container-component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 2,
+          "offset": 50,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+    {
+      "attributes": {},
+      "children": [],
+      "data": {
+        "hName": "container-component",
+        "hProperties": {
+          ":items": "{\\"key\\":\\"value\\"}",
+        },
+      },
+      "fmAttributes": {
+        "items": {
+          "key": "value",
+        },
+      },
+      "name": "container-component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 9,
+          "offset": 104,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+          "offset": 52,
+        },
+      },
+      "rawData": "
+items:
+  key: value
+---",
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 9,
+      "offset": 104,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
 exports[`block-component > dangling-list 1`] = `
 {
   "children": [

--- a/test/block-component.test.ts
+++ b/test/block-component.test.ts
@@ -196,6 +196,67 @@ describe('block-component', () => {
         expect(ast.children[0].type).toBe('textComponent')
         expect(ast.children[0].name).toBe('component')
       }
+    },
+    'component-attributes-bind-frontmatter': {
+      markdown: '::text-component{:key="value"}\n::',
+      extra (_, ast) {
+        expect(ast.children[0].attributes).toEqual({ ':key': 'value' })
+        expect(ast.children[0].data.hProperties).toEqual({ ':key': 'value' })
+      }
+    },
+    'component-attributes-array-of-string': {
+      markdown: '::container-component{:items=\'["Nuxt", "Vue"]\'}\n::',
+      // expected: '::container-component{:items="[&#x22;Nuxt&#x22;, &#x22;Vue&#x22;]"}\n::',
+      extra (_, ast) {
+        expect(ast.children[0].attributes).toEqual({ ':items': '["Nuxt", "Vue"]' })
+        expect(ast.children[0].data.hProperties).toEqual({ ':items': '["Nuxt", "Vue"]' })
+      }
+    },
+    'component-attributes-bad-array': {
+      markdown: '::container-component{:items="[Nuxt,Vue]"}\n::',
+      extra (_, ast) {
+        expect(ast.children[0].attributes).toEqual({ ':items': '[Nuxt,Vue]' })
+        expect(ast.children[0].data.hProperties).toEqual({ ':items': '[Nuxt,Vue]' })
+      }
+    },
+    'component-attributes-array-of-number': {
+      markdown: '::container-component{:items=\'[1,2,3.5]\'}\n::',
+      extra (_, ast) {
+        expect(ast.children[0].attributes).toEqual({ ':items': '[1,2,3.5]' })
+        expect(ast.children[0].data.hProperties).toEqual({ ':items': '[1,2,3.5]' })
+      }
+    },
+    'component-attributes-array-convert-double-quote': {
+      markdown: '::container-component{:items="[1,2,3.5]"}\n::',
+      expected: '::container-component{:items=\'[1,2,3.5]\'}\n::',
+      extra (_, ast) {
+        expect(ast.children[0].attributes).toEqual({ ':items': '[1,2,3.5]' })
+        expect(ast.children[0].data.hProperties).toEqual({ ':items': '[1,2,3.5]' })
+      }
+    },
+    'component-attributes-object': {
+      markdown: '::container-component{:items=\'{"key": "value"}\'}\n::',
+      extra (_, ast) {
+        expect(ast.children[0].attributes).toEqual({ ':items': '{"key": "value"}' })
+        expect(ast.children[0].data.hProperties).toEqual({ ':items': '{"key": "value"}' })
+      }
+    },
+    'component-hProperties-be-the-same': {
+      markdown: [
+        '::container-component{:items=\'{"key":"value"}\'}\n::',
+        '',
+        '::container-component',
+        '---',
+        'items:',
+        '  key: value',
+        '---',
+        '::'
+      ].join('\n'),
+      extra (_, ast) {
+        expect(ast.children[0].attributes).toEqual({ ':items': '{"key":"value"}' })
+        expect(ast.children[1].attributes).toEqual({})
+        expect(ast.children[0].data.hProperties).toEqual(ast.children[1].data.hProperties)
+      }
     }
   })
 })


### PR DESCRIPTION
Hi!

I fixed a bug that occur only on transformation from AST to markdown when a component has an array attribute.

Input :
```md
::container-component{:items='["Nuxt", "Vue"]'}
::
```
[Before](https://github.com/ManUtopiK/remark-mdc/blob/fixArrayOfString/test/block-component.test.ts#L209) :
```md
::container-component{:items="[&#x22;Nuxt&#x22;, &#x22;Vue&#x22;]"}
::
```
After this fix :
```md
::container-component{:items='["Nuxt", "Vue"]'}
::
```

I followed the spec of [the JSON string](https://remark-mdc.nuxt.space/#inline-props).

I added a bunch of tests around component's attributes...