### PR TITLE
Fix/parse component props object

### DIFF
--- a/src/to-markdown.ts
+++ b/src/to-markdown.ts
@@ -109,8 +109,8 @@ export default (opts: RemarkMDCOptions = {}) => {
       const attrs = Object.entries(fmAttributes)
         .sort(([key1], [key2]) => key1.localeCompare(key2))
         .reduce((acc, [key, value2]) => {
-          // Stringify only JSON objects. `{":key:": "value"}` can be used for binding data to frontmatter.
-          if (key?.startsWith(':') && typeof value2 !== 'string') {
+          // Parse only JSON objects. `{":key:": "value"}` can be used for binding data to frontmatter.
+          if (key?.startsWith(':') && isValidJSON(value2)) {
             try {
               value2 = JSON.parse(value2)
             } catch {

--- a/test/__snapshots__/block-component.test.ts.snap
+++ b/test/__snapshots__/block-component.test.ts.snap
@@ -99,13 +99,13 @@ exports[`block-component > component-attributes-array-of-string 1`] = `
   "children": [
     {
       "attributes": {
-        ":items": "["Nuxt", "Vue"]",
+        ":items": "[\\"Nuxt\\", \\"Vue\\"]",
       },
       "children": [],
       "data": {
         "hName": "container-component",
         "hProperties": {
-          ":items": "["Nuxt", "Vue"]",
+          ":items": "[\\"Nuxt\\", \\"Vue\\"]",
         },
       },
       "fmAttributes": {},
@@ -240,13 +240,13 @@ exports[`block-component > component-attributes-object 1`] = `
   "children": [
     {
       "attributes": {
-        ":items": "{"key": "value"}",
+        ":items": "{\\"key\\": \\"value\\"}",
       },
       "children": [],
       "data": {
         "hName": "container-component",
         "hProperties": {
-          ":items": "{"key": "value"}",
+          ":items": "{\\"key\\": \\"value\\"}",
         },
       },
       "fmAttributes": {},
@@ -287,13 +287,13 @@ exports[`block-component > component-hProperties-be-the-same 1`] = `
   "children": [
     {
       "attributes": {
-        ":items": "{"key":"value"}",
+        ":items": "{\\"key\\":\\"value\\"}",
       },
       "children": [],
       "data": {
         "hName": "container-component",
         "hProperties": {
-          ":items": "{"key":"value"}",
+          ":items": "{\\"key\\":\\"value\\"}",
         },
       },
       "fmAttributes": {},
@@ -318,7 +318,7 @@ exports[`block-component > component-hProperties-be-the-same 1`] = `
       "data": {
         "hName": "container-component",
         "hProperties": {
-          ":items": "{"key":"value"}",
+          ":items": "{\\"key\\":\\"value\\"}",
         },
       },
       "fmAttributes": {
@@ -709,7 +709,7 @@ exports[`block-component > frontmatter 1`] = `
       "data": {
         "hName": "with-frontmatter",
         "hProperties": {
-          ":array": "["item",{"itemKey":"value"}]",
+          ":array": "[\\"item\\",{\\"itemKey\\":\\"value\\"}]",
           "key": "value",
         },
       },
@@ -769,9 +769,9 @@ exports[`block-component > frontmatter-with-binding-variables 1`] = `
       "data": {
         "hName": "with-frontmatter",
         "hProperties": {
-          ":array": "["item",{":itemKey":"value"}]",
+          ":array": "[\\"item\\",{\\":itemKey\\":\\"value\\"}]",
           ":key": "value",
-          ":object": "{":subkey":"value","subkey2":"value"}",
+          ":object": "{\\":subkey\\":\\"value\\",\\"subkey2\\":\\"value\\"}",
         },
       },
       "fmAttributes": {
@@ -837,8 +837,8 @@ exports[`block-component > frontmatter1 1`] = `
       "data": {
         "hName": "with-frontmatter",
         "hProperties": {
-          ":array": "["item",{"itemKey":"value"}]",
-          ":key2": "{"subkey":"value","subkey2":"value"}",
+          ":array": "[\\"item\\",{\\"itemKey\\":\\"value\\"}]",
+          ":key2": "{\\"subkey\\":\\"value\\",\\"subkey2\\":\\"value\\"}",
           "key": "value",
         },
       },
@@ -1188,7 +1188,7 @@ exports[`block-component > nested-component 1`] = `
       "data": {
         "hName": "with-frontmatter-and-nested-component",
         "hProperties": {
-          ":array": "["item",{"itemKey":"value"}]",
+          ":array": "[\\"item\\",{\\"itemKey\\":\\"value\\"}]",
           "key": "value",
         },
       },

--- a/test/__snapshots__/codeblock-props.test.ts.snap
+++ b/test/__snapshots__/codeblock-props.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`basic > YamlProps 1`] = `
+exports[`codeblock-props > YamlProps 1`] = `
 {
   "children": [
     {
@@ -9,7 +9,7 @@ exports[`basic > YamlProps 1`] = `
       "data": {
         "hName": "with-frontmatter-yaml",
         "hProperties": {
-          ":array": "["item",{"itemKey":"value"}]",
+          ":array": "[\\"item\\",{\\"itemKey\\":\\"value\\"}]",
           "key": "value",
         },
       },
@@ -59,7 +59,7 @@ key: value
 }
 `;
 
-exports[`basic > nested-component-yamlProps 1`] = `
+exports[`codeblock-props > nested-component-yamlProps 1`] = `
 {
   "children": [
     {
@@ -189,7 +189,7 @@ exports[`basic > nested-component-yamlProps 1`] = `
       "data": {
         "hName": "with-frontmatter-and-nested-component-yaml",
         "hProperties": {
-          ":array": "["item",{"itemKey":"value"}]",
+          ":array": "[\\"item\\",{\\"itemKey\\":\\"value\\"}]",
           "key": "value",
         },
       },
@@ -239,7 +239,7 @@ key: value
 }
 `;
 
-exports[`basic > notYamlProps 1`] = `
+exports[`codeblock-props > notYamlProps 1`] = `
 {
   "children": [
     {
@@ -304,7 +304,7 @@ array:
 }
 `;
 
-exports[`basic > notYamlProps2 1`] = `
+exports[`codeblock-props > notYamlProps2 1`] = `
 {
   "children": [
     {
@@ -369,7 +369,7 @@ array:
 }
 `;
 
-exports[`basic > notYamlProps3 1`] = `
+exports[`codeblock-props > notYamlProps3 1`] = `
 {
   "children": [
     {
@@ -434,7 +434,7 @@ array:
 }
 `;
 
-exports[`basic > shouldConvertYamlProps 1`] = `
+exports[`codeblock-props > shouldConvertYamlProps 1`] = `
 {
   "children": [
     {
@@ -443,7 +443,7 @@ exports[`basic > shouldConvertYamlProps 1`] = `
       "data": {
         "hName": "with-frontmatter-yaml",
         "hProperties": {
-          ":array": "["item",{"itemKey":"value"}]",
+          ":array": "[\\"item\\",{\\"itemKey\\":\\"value\\"}]",
           "key": "value",
         },
       },
@@ -494,7 +494,66 @@ key: value
 }
 `;
 
-exports[`basic > yamlProps1 1`] = `
+exports[`codeblock-props > shouldConvertYamlPropsWithoutOption 1`] = `
+{
+  "children": [
+    {
+      "attributes": {},
+      "children": [],
+      "data": {
+        "hName": "with-frontmatter-yaml",
+        "hProperties": {
+          ":array": "[\\"item\\",{\\"itemKey\\":\\"value\\"}]",
+          "key": "value",
+        },
+      },
+      "fmAttributes": {
+        "array": [
+          "item",
+          {
+            "itemKey": "value",
+          },
+        ],
+        "key": "value",
+      },
+      "name": "with-frontmatter-yaml",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 8,
+          "offset": 92,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "rawData": "array:
+  - item
+  - itemKey: value
+key: value
+---",
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 8,
+      "offset": 92,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`codeblock-props > yamlProps1 1`] = `
 {
   "children": [
     {
@@ -503,8 +562,8 @@ exports[`basic > yamlProps1 1`] = `
       "data": {
         "hName": "with-frontmatter-yaml1",
         "hProperties": {
-          ":array": "["item",{"itemKey":"value"}]",
-          ":key2": "{"subkey":"value","subkey2":"value"}",
+          ":array": "[\\"item\\",{\\"itemKey\\":\\"value\\"}]",
+          ":key2": "{\\"subkey\\":\\"value\\",\\"subkey2\\":\\"value\\"}",
           "key": "value",
         },
       },

--- a/test/codeblock-props.test.ts
+++ b/test/codeblock-props.test.ts
@@ -1,7 +1,7 @@
 import { expect, describe } from 'vitest'
 import { runMarkdownTests } from './utils'
 
-describe('basic', () => {
+describe('codeblock-props', () => {
   runMarkdownTests({
     YamlProps: {
       mdcOptions: {
@@ -51,6 +51,10 @@ describe('basic', () => {
       },
       markdown: '::with-frontmatter-yaml\n---\narray:\n  - item\n  - itemKey: value\nkey: value\n---\n::',
       expected: '::with-frontmatter-yaml\n```yaml [props]\narray:\n  - item\n  - itemKey: value\nkey: value\n```\n::'
+    },
+    shouldConvertYamlPropsWithoutOption: {
+      markdown: '::with-frontmatter-yaml\n```yaml [props]\narray:\n  - item\n  - itemKey: value\nkey: value\n```\n::',
+      expected: '::with-frontmatter-yaml\n---\narray:\n  - item\n  - itemKey: value\nkey: value\n---\n::'
     },
     yamlProps1: {
       mdcOptions: {


### PR DESCRIPTION
When converting from AST to md, we need to parse only a valid JSON object to create a container component frontmatter. Relying on typeof `string` is not enough.
I also renamed test and added a simple check for yaml component props style.