### PR TITLE
Correctly name the plugin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ interface ComponentNode extends Node {
   children?: ChildrenNode[]
 }
 
-export default <Plugin<Array<RemarkMDCOptions>>> function (opts: RemarkMDCOptions = {}) {
+export default <Plugin<Array<RemarkMDCOptions>>> function remarkMDC (opts: RemarkMDCOptions = {}) {
   const data: Record<string, any> = this.data()
 
   add('micromarkExtensions', syntax())

--- a/test/__snapshots__/basic.test.ts.snap
+++ b/test/__snapshots__/basic.test.ts.snap
@@ -282,6 +282,25 @@ exports[`basic > link 1`] = `
 }
 `;
 
+exports[`basic > remarkPluginName 1`] = `
+{
+  "children": [],
+  "position": {
+    "end": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
 exports[`basic > simple 1`] = `
 {
   "children": [

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1,8 +1,20 @@
-import { describe } from 'vitest'
+import { expect, describe } from 'vitest'
 import { runMarkdownTests } from './utils'
 
 describe('basic', () => {
+  let attachers
   runMarkdownTests({
+    remarkPluginName: {
+      markdown: '',
+      plugins: [
+        function test () {
+          attachers = this.attachers
+        }
+      ],
+      extra () {
+        expect(attachers.map(a => a[0].name)).toContain('remarkMDC')
+      }
+    },
     simple: {
       mdcOptions: {
         experimental: {


### PR DESCRIPTION
Name the plugin to see it in `Processor`.
With this, we can, for example, check in other unified plugins or in the compiler/parser if the plugin is well attached.

Before :

![image](https://github.com/nuxtlabs/remark-mdc/assets/188172/6d9efa64-be03-4d73-a892-a26f9435fa1d)

After :

![image](https://github.com/nuxtlabs/remark-mdc/assets/188172/3c1c0d39-7589-4aa6-a3e0-b9b73f897a7c)


