### PR TITLE
feat: supports escape dot for `unflatten`

### DIFF
--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -1,5 +1,5 @@
 import { parse, stringify } from 'yaml'
-import * as flat from 'flat'
+import { unflatten } from './utils'
 
 const FRONTMATTER_DELIMITER_DEFAULT = '---'
 const FRONTMATTER_DELIMITER_CODEBLOCK_STYLE = '```yaml [props]'
@@ -9,7 +9,7 @@ export function stringifyFrontMatter (data: any, content = '') {
     return ''
   }
 
-  data = flat.unflatten(data || {}, {})
+  data = unflatten(data || {})
 
   return [
     FRONTMATTER_DELIMITER_DEFAULT,
@@ -24,7 +24,7 @@ export function stringifyCodeBlockProps (data: any, content = '') {
     return ''
   }
 
-  data = flat.unflatten(data || {}, {})
+  data = unflatten(data || {})
 
   return [
     FRONTMATTER_DELIMITER_CODEBLOCK_STYLE,
@@ -49,7 +49,6 @@ export function parseFrontMatter (content: string) {
 
   return {
     content,
-    // unflatten frontmatter data. convert `parent.child` keys into `parent: { child: ... }`
-    data: flat.unflatten(data || {}, {}) as Record<string, any>
+    data: unflatten(data || {}) as Record<string, any>
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,46 @@
+import { unflatten as _unflatten } from 'flat'
+
 export const NON_UNWRAPPABLE_TYPES = [
   'componentContainerSection',
   'componentContainerDataSection',
   'containerComponent',
   'leafComponent'
 ]
+
+// unflatten frontmatter data. convert `parent.child` keys into `parent: { child: ... }`
+// supports escaping \. to . and \\ to \
+export function unflatten (obj: any) {
+  // prevent happened to use eascape placeholder
+  const salt = Math.random().toString(36).slice(2, 11)
+  const escapePlaceholder = `__ESCAPED_DOT_${salt}__`
+  const escapeBackslashPlaceholder = `__ESCAPED_BACKSLASH_${salt}__`
+  const escapedDotRegex = new RegExp(escapePlaceholder, 'g')
+  const escapedBackslashRegex = new RegExp(escapeBackslashPlaceholder, 'g')
+
+  function escapeDotsInKeys (o: Record<string, any>): Record<string, any> {
+    return Object.fromEntries(
+      Object.entries(o).map(([key, value]) => [
+        key.replace(/\\\\/g, escapeBackslashPlaceholder)
+          .replace(/\\\./g, escapePlaceholder),
+        value
+      ])
+    )
+  }
+
+  function restoreEscapedChars (o: any): any {
+    if (typeof o !== 'object' || o === null) { return o }
+    if (Array.isArray(o)) { return o.map(restoreEscapedChars) }
+
+    const restored: Record<string, any> = {}
+    for (const [key, value] of Object.entries(o)) {
+      const restoredKey = key.replace(escapedDotRegex, '.')
+        .replace(escapedBackslashRegex, '\\')
+      restored[restoredKey] = restoreEscapedChars(value)
+    }
+    return restored
+  }
+
+  const escapedObj = escapeDotsInKeys(obj)
+  const unflattenedObj = _unflatten(escapedObj)
+  return restoreEscapedChars(unflattenedObj)
+}

--- a/test/unflatten.test.ts
+++ b/test/unflatten.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from 'vitest'
+import { unflatten } from '../src/utils'
+
+describe('unflatten', () => {
+  test('should able to escape dot', () => {
+    expect(unflatten({
+      key1: 1,
+      'key2.subkey': 2,
+      'key3\\.subkeys': 3,
+      'key4\\\\.subkeys': 4,
+      'key5\\..\\.subkeys': 5,
+      'key6\\\\.\\.subkeys': 6
+    })).toMatchInlineSnapshot(`
+      {
+        "key1": 1,
+        "key2": {
+          "subkey": 2,
+        },
+        "key3.subkeys": 3,
+        "key4\\": {
+          "subkeys": 4,
+        },
+        "key5.": {
+          ".subkeys": 5,
+        },
+        "key6\\": {
+          ".subkeys": 6,
+        },
+      }
+    `)
+  })
+})


### PR DESCRIPTION
Fix #87

This PR adds support for escaping dots in keys when using the `flat.funflatten`.

Please see test unit inside `unflatten.test.ts` for more details of handling escaped cases.

## Need Help

In `frontmatter.ts`, it works well in `parseFrontMatter`. But I'm not sure why need to call `unflatten` again inside  `stringifyFrontMatter` & `stringifyCodeBlockProps`, does it need to be flattened instead of unflattened?
