### PR TITLE
docs: correctly close block components on "Slots" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Default slot text
 
 #description
 This will be rendered inside the `description` slot.
+::
 ```
 
 ### `:::` Nesting


### PR DESCRIPTION
I was making "kitchen sink" sort of examples for project with examples from `README.md`, and got confused about why nesting does not work correctly.

It turns out that example on "Slots" section had an unclosed block component.