### PR TITLE
fix: allow using `#` in class name

### DIFF
--- a/src/micromark-extension/factory-attributes.ts
+++ b/src/micromark-extension/factory-attributes.ts
@@ -117,7 +117,7 @@ export default function createAttributes(
       return nok(code)
     }
 
-    if (code === Codes.hash || code === Codes.dot || code === Codes.closingCurlyBracket || markdownLineEndingOrSpace(code)) {
+    if (code === Codes.dot || code === Codes.closingCurlyBracket || markdownLineEndingOrSpace(code)) {
       effects.exit(type + 'Value' as keyof TokenTypeMap)
       effects.exit(type)
       effects.exit(attributeType)

--- a/src/to-markdown.ts
+++ b/src/to-markdown.ts
@@ -14,7 +14,7 @@ import type { Container } from './micromark-extension/types'
 
 type NodeContainerComponent = Parents & { name: string, fmAttributes?: Record<string, any> }
 
-const shortcut = /^[^\t\n\r "#'.<=>`}]+$/
+const shortcut = /^[^\t\n\r "'.<=>`}]+$/
 const baseFence = 2
 
 // import { defaultHandlers } from 'mdast-util-to-markdown/lib/util/compile-pattern'

--- a/test/__snapshots__/attributes.test.ts.snap
+++ b/test/__snapshots__/attributes.test.ts.snap
@@ -1,5 +1,62 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Attributes > # in class 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "attributes": {
+            "class": "bg-[#E74249]",
+            "id": "id",
+          },
+          "position": {
+            "end": {
+              "column": 7,
+              "line": 1,
+              "offset": 6,
+            },
+            "start": {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "inlineCode",
+          "value": "code",
+        },
+      ],
+      "position": {
+        "end": {
+          "column": 26,
+          "line": 1,
+          "offset": 25,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 26,
+      "line": 1,
+      "offset": 25,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
 exports[`Attributes > boolean 1`] = `
 {
   "children": [

--- a/test/attributes.test.ts
+++ b/test/attributes.test.ts
@@ -49,6 +49,9 @@ describe('Attributes', () => {
     'code': {
       markdown: '`code`{#id .class}',
     },
+    '# in class': {
+      markdown: '`code`{#id .bg-[#E74249]}',
+    },
     'strong': {
       markdown: '**strong**{#id .class}',
     },


### PR DESCRIPTION
resolves https://github.com/nuxt-content/remark-mdc/issues/109