### PR TITLE
fix: fenced code block indentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ Temporary Items
 .env
 .netlify
 .data
+playground/.data

--- a/src/micromark-extension/tokenize-container.ts
+++ b/src/micromark-extension/tokenize-container.ts
@@ -35,6 +35,15 @@ function tokenize(this: TokenizeContext, effects: Effects, ok: State, nok: State
    */
   let visitingCodeFenced = false
 
+  /**
+   * Whether the currently-open code fence was opened after `containerIndentSize` spaces
+   * were stripped from its opening line. When `true`, the same stripping applies to
+   * content lines inside the fence. When `false`, either no fence is open or the open
+   * fence was at column 0 (no stripping applied), so content lines must NOT be stripped.
+   * Reset to `false` each time a fence closes.
+   */
+  let codeFenceStripped = false
+
   const section = useTokenState('componentContainerSection')
 
   /**
@@ -205,11 +214,15 @@ function tokenize(this: TokenizeContext, effects: Effects, ok: State, nok: State
       return after(code)
     }
 
-    // Check for code fence
-    if (code === Codes.backTick) {
+    // Check for code fence (backtick or tilde delimiters)
+    if (code === Codes.backTick || code === Codes.tilde) {
       return effects.check(
         tokenizeCodeFence,
         (code) => {
+          if (visitingCodeFenced) {
+            // Fence is closing; reset so the next fence starts fresh.
+            codeFenceStripped = false
+          }
           visitingCodeFenced = !visitingCodeFenced
           return chunkStart(code)
         },
@@ -246,14 +259,44 @@ function tokenize(this: TokenizeContext, effects: Effects, ok: State, nok: State
 
   function dentendIndentedCommponent(code: Code): State | undefined {
     if (containerIndentSize) {
-      return factorySpace(effects, lineStartAfterPrefix, 'linePrefix', containerIndentSize + 1)(code)
+      // Inside a code fence opened without stripping (at column 0): skip stripping
+      // so that genuine code indentation is preserved.
+      if (visitingCodeFenced && !codeFenceStripped) {
+        return lineStartAfterPrefix(code)
+      }
+      const checkpoint = self.events.length
+      return factorySpace(effects, (code2: Code) => {
+        // When opening a new fence, record whether containerIndentSize spaces were
+        // fully stripped from its opening line. Slice from checkpoint so only the
+        // spaces consumed by this factorySpace call are counted, not any outer
+        // linePrefix tokens already on the event stream from lineStart.
+        if ((code2 === Codes.backTick || code2 === Codes.tilde) && !visitingCodeFenced) {
+          codeFenceStripped = linePrefixSize(self.events.slice(checkpoint)) >= containerIndentSize
+        }
+        return lineStartAfterPrefix(code2)
+      }, 'linePrefix', containerIndentSize + 1)(code)
     }
     return lineStartAfterPrefix(code)
   }
 
   function attemptIntentedCommponent(code: Code): State | undefined {
     if (containerIndentSize) {
-      return factorySpace(effects, lineStartAfterPrefix, 'linePrefix', containerIndentSize + 1)(code)
+      // Inside a code fence opened without stripping (at column 0): skip stripping.
+      if (visitingCodeFenced && !codeFenceStripped) {
+        return lineStartAfterPrefix(code)
+      }
+      const checkpoint = self.events.length
+      return factorySpace(effects, (code2: Code) => {
+        if ((code2 === Codes.backTick || code2 === Codes.tilde) && !visitingCodeFenced) {
+          codeFenceStripped = linePrefixSize(self.events.slice(checkpoint)) >= containerIndentSize
+        }
+        return lineStartAfterPrefix(code2)
+      }, 'linePrefix', containerIndentSize + 1)(code)
+    }
+    // When containerIndentSize is 0 and inside a code fence, bypass the indented-component
+    // check — fence content must never trigger sub-component detection.
+    if (visitingCodeFenced) {
+      return lineStartAfterPrefix(code)
     }
 
     return effects.check({ tokenize: tokenizeContainerIndent, partial: true },

--- a/test/__snapshots__/block-component.test.ts.snap
+++ b/test/__snapshots__/block-component.test.ts.snap
@@ -1397,6 +1397,300 @@ exports[`block-component > ignore-code-fence 1`] = `
 }
 `;
 
+exports[`block-component > ignore-code-fence-with-prior-indented-subcomponent 1`] = `
+{
+  "children": [
+    {
+      "attributes": {},
+      "children": [
+        {
+          "attributes": {},
+          "children": [],
+          "data": {
+            "hName": "nested",
+            "hProperties": {},
+          },
+          "fmAttributes": {},
+          "name": "nested",
+          "position": {
+            "end": {
+              "column": 6,
+              "line": 4,
+              "offset": 30,
+            },
+            "start": {
+              "column": 3,
+              "line": 3,
+              "offset": 15,
+            },
+          },
+          "type": "containerComponent",
+        },
+        {
+          "lang": "json",
+          "meta": null,
+          "position": {
+            "end": {
+              "column": 4,
+              "line": 10,
+              "offset": 64,
+            },
+            "start": {
+              "column": 1,
+              "line": 6,
+              "offset": 32,
+            },
+          },
+          "type": "code",
+          "value": "{
+  "key": "value"
+}",
+        },
+      ],
+      "data": {
+        "hName": "component",
+        "hProperties": {},
+      },
+      "fmAttributes": {},
+      "name": "component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 11,
+          "offset": 67,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 11,
+      "offset": 67,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block-component > ignore-code-fence-with-prior-indented-subcomponent-blank-line 1`] = `
+{
+  "children": [
+    {
+      "attributes": {},
+      "children": [
+        {
+          "attributes": {},
+          "children": [],
+          "data": {
+            "hName": "nested",
+            "hProperties": {},
+          },
+          "fmAttributes": {},
+          "name": "nested",
+          "position": {
+            "end": {
+              "column": 6,
+              "line": 4,
+              "offset": 30,
+            },
+            "start": {
+              "column": 3,
+              "line": 3,
+              "offset": 15,
+            },
+          },
+          "type": "containerComponent",
+        },
+        {
+          "children": [
+            {
+              "position": {
+                "end": {
+                  "column": 10,
+                  "line": 6,
+                  "offset": 41,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 6,
+                  "offset": 32,
+                },
+              },
+              "type": "text",
+              "value": "Some text",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 10,
+              "line": 6,
+              "offset": 41,
+            },
+            "start": {
+              "column": 1,
+              "line": 6,
+              "offset": 32,
+            },
+          },
+          "type": "paragraph",
+        },
+        {
+          "lang": "json",
+          "meta": null,
+          "position": {
+            "end": {
+              "column": 4,
+              "line": 12,
+              "offset": 75,
+            },
+            "start": {
+              "column": 1,
+              "line": 8,
+              "offset": 43,
+            },
+          },
+          "type": "code",
+          "value": "{
+  "key": "value"
+}",
+        },
+      ],
+      "data": {
+        "hName": "component",
+        "hProperties": {},
+      },
+      "fmAttributes": {},
+      "name": "component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 13,
+          "offset": 78,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 13,
+      "offset": 78,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block-component > indented-code-fence-with-prior-indented-subcomponent 1`] = `
+{
+  "children": [
+    {
+      "attributes": {},
+      "children": [
+        {
+          "attributes": {},
+          "children": [],
+          "data": {
+            "hName": "nested",
+            "hProperties": {},
+          },
+          "fmAttributes": {},
+          "name": "nested",
+          "position": {
+            "end": {
+              "column": 6,
+              "line": 4,
+              "offset": 30,
+            },
+            "start": {
+              "column": 3,
+              "line": 3,
+              "offset": 15,
+            },
+          },
+          "type": "containerComponent",
+        },
+        {
+          "lang": "json",
+          "meta": null,
+          "position": {
+            "end": {
+              "column": 6,
+              "line": 10,
+              "offset": 74,
+            },
+            "start": {
+              "column": 3,
+              "line": 6,
+              "offset": 34,
+            },
+          },
+          "type": "code",
+          "value": "{
+  "key": "value"
+}",
+        },
+      ],
+      "data": {
+        "hName": "component",
+        "hProperties": {},
+      },
+      "fmAttributes": {},
+      "name": "component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 11,
+          "offset": 77,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 11,
+      "offset": 77,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
 exports[`block-component > jsonScapeAttr 1`] = `
 {
   "children": [
@@ -2817,6 +3111,213 @@ exports[`block-component > text 1`] = `
 }
 `;
 
+exports[`block-component > tilde-code-fence-blank-line-before 1`] = `
+{
+  "children": [
+    {
+      "attributes": {},
+      "children": [
+        {
+          "attributes": {},
+          "children": [],
+          "data": {
+            "hName": "nested",
+            "hProperties": {},
+          },
+          "fmAttributes": {},
+          "name": "nested",
+          "position": {
+            "end": {
+              "column": 6,
+              "line": 4,
+              "offset": 30,
+            },
+            "start": {
+              "column": 3,
+              "line": 3,
+              "offset": 15,
+            },
+          },
+          "type": "containerComponent",
+        },
+        {
+          "children": [
+            {
+              "position": {
+                "end": {
+                  "column": 10,
+                  "line": 6,
+                  "offset": 41,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 6,
+                  "offset": 32,
+                },
+              },
+              "type": "text",
+              "value": "Some text",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 10,
+              "line": 6,
+              "offset": 41,
+            },
+            "start": {
+              "column": 1,
+              "line": 6,
+              "offset": 32,
+            },
+          },
+          "type": "paragraph",
+        },
+        {
+          "lang": "json",
+          "meta": null,
+          "position": {
+            "end": {
+              "column": 4,
+              "line": 12,
+              "offset": 75,
+            },
+            "start": {
+              "column": 1,
+              "line": 8,
+              "offset": 43,
+            },
+          },
+          "type": "code",
+          "value": "{
+  "key": "value"
+}",
+        },
+      ],
+      "data": {
+        "hName": "component",
+        "hProperties": {},
+      },
+      "fmAttributes": {},
+      "name": "component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 13,
+          "offset": 78,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 13,
+      "offset": 78,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block-component > tilde-code-fence-with-prior-indented-subcomponent 1`] = `
+{
+  "children": [
+    {
+      "attributes": {},
+      "children": [
+        {
+          "attributes": {},
+          "children": [],
+          "data": {
+            "hName": "nested",
+            "hProperties": {},
+          },
+          "fmAttributes": {},
+          "name": "nested",
+          "position": {
+            "end": {
+              "column": 6,
+              "line": 4,
+              "offset": 30,
+            },
+            "start": {
+              "column": 3,
+              "line": 3,
+              "offset": 15,
+            },
+          },
+          "type": "containerComponent",
+        },
+        {
+          "lang": "json",
+          "meta": null,
+          "position": {
+            "end": {
+              "column": 4,
+              "line": 10,
+              "offset": 64,
+            },
+            "start": {
+              "column": 1,
+              "line": 6,
+              "offset": 32,
+            },
+          },
+          "type": "code",
+          "value": "{
+  "key": "value"
+}",
+        },
+      ],
+      "data": {
+        "hName": "component",
+        "hProperties": {},
+      },
+      "fmAttributes": {},
+      "name": "component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 11,
+          "offset": 67,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 11,
+      "offset": 67,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
 exports[`block-component > trim-slot-name 1`] = `
 {
   "children": [
@@ -2908,6 +3409,216 @@ exports[`block-component > trim-slot-name 1`] = `
       "column": 3,
       "line": 4,
       "offset": 34,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block-component > two-code-fences-column-zero-then-indented 1`] = `
+{
+  "children": [
+    {
+      "attributes": {},
+      "children": [
+        {
+          "attributes": {},
+          "children": [],
+          "data": {
+            "hName": "nested",
+            "hProperties": {},
+          },
+          "fmAttributes": {},
+          "name": "nested",
+          "position": {
+            "end": {
+              "column": 6,
+              "line": 4,
+              "offset": 30,
+            },
+            "start": {
+              "column": 3,
+              "line": 3,
+              "offset": 15,
+            },
+          },
+          "type": "containerComponent",
+        },
+        {
+          "lang": "json",
+          "meta": null,
+          "position": {
+            "end": {
+              "column": 4,
+              "line": 10,
+              "offset": 63,
+            },
+            "start": {
+              "column": 1,
+              "line": 6,
+              "offset": 32,
+            },
+          },
+          "type": "code",
+          "value": "{
+  "first": true
+}",
+        },
+        {
+          "lang": "json",
+          "meta": null,
+          "position": {
+            "end": {
+              "column": 6,
+              "line": 14,
+              "offset": 101,
+            },
+            "start": {
+              "column": 3,
+              "line": 12,
+              "offset": 67,
+            },
+          },
+          "type": "code",
+          "value": "{ "second": true }",
+        },
+      ],
+      "data": {
+        "hName": "component",
+        "hProperties": {},
+      },
+      "fmAttributes": {},
+      "name": "component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 15,
+          "offset": 104,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 15,
+      "offset": 104,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block-component > two-code-fences-indented-then-column-zero 1`] = `
+{
+  "children": [
+    {
+      "attributes": {},
+      "children": [
+        {
+          "attributes": {},
+          "children": [],
+          "data": {
+            "hName": "nested",
+            "hProperties": {},
+          },
+          "fmAttributes": {},
+          "name": "nested",
+          "position": {
+            "end": {
+              "column": 6,
+              "line": 4,
+              "offset": 30,
+            },
+            "start": {
+              "column": 3,
+              "line": 3,
+              "offset": 15,
+            },
+          },
+          "type": "containerComponent",
+        },
+        {
+          "lang": "json",
+          "meta": null,
+          "position": {
+            "end": {
+              "column": 6,
+              "line": 8,
+              "offset": 67,
+            },
+            "start": {
+              "column": 3,
+              "line": 6,
+              "offset": 34,
+            },
+          },
+          "type": "code",
+          "value": "{ "first": true }",
+        },
+        {
+          "lang": "json",
+          "meta": null,
+          "position": {
+            "end": {
+              "column": 4,
+              "line": 14,
+              "offset": 101,
+            },
+            "start": {
+              "column": 1,
+              "line": 10,
+              "offset": 69,
+            },
+          },
+          "type": "code",
+          "value": "{
+  "second": true
+}",
+        },
+      ],
+      "data": {
+        "hName": "component",
+        "hProperties": {},
+      },
+      "fmAttributes": {},
+      "name": "component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 15,
+          "offset": 104,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 15,
+      "offset": 104,
     },
     "start": {
       "column": 1,

--- a/test/block-component.test.ts
+++ b/test/block-component.test.ts
@@ -236,6 +236,283 @@ describe('block-component', () => {
         'Third line',
       ].join('\n'),
     },
+    'ignore-code-fence-with-prior-indented-subcomponent': {
+      // Code fence at column 0 must NOT have its content indentation stripped,
+      // even when a prior indented sub-component set containerIndentSize > 0.
+      // The leading blank line after ::component is normalized away on stringify.
+      markdown: [
+        '::component',
+        '',
+        '  :::nested',
+        '  :::',
+        '',
+        '```json',
+        '{',
+        '  "key": "value"',
+        '}',
+        '```',
+        '::',
+      ].join('\n'),
+      expected: [
+        '::component',
+        '  :::nested',
+        '  :::',
+        '',
+        '```json',
+        '{',
+        '  "key": "value"',
+        '}',
+        '```',
+        '::',
+      ].join('\n'),
+      extra: (_md, ast) => {
+        const container = ast.children[0]
+        const codeNode = container.children[1]
+        expect(codeNode.type).toBe('code')
+        expect(codeNode.value).toBe('{\n  "key": "value"\n}')
+      },
+    },
+    'ignore-code-fence-with-prior-indented-subcomponent-blank-line': {
+      // Same as above but with a blank line immediately before the code fence,
+      // which triggers the `possibleIndentedComponent` / attemptIntentedCommponent path.
+      // The leading blank line after ::component is normalized away on stringify.
+      markdown: [
+        '::component',
+        '',
+        '  :::nested',
+        '  :::',
+        '',
+        'Some text',
+        '',
+        '```json',
+        '{',
+        '  "key": "value"',
+        '}',
+        '```',
+        '::',
+      ].join('\n'),
+      expected: [
+        '::component',
+        '  :::nested',
+        '  :::',
+        '',
+        'Some text',
+        '',
+        '```json',
+        '{',
+        '  "key": "value"',
+        '}',
+        '```',
+        '::',
+      ].join('\n'),
+      extra: (_md, ast) => {
+        const container = ast.children[0]
+        // children[0] = nested container, children[1] = paragraph, children[2] = code
+        const codeNode = container.children[2]
+        expect(codeNode.type).toBe('code')
+        expect(codeNode.value).toBe('{\n  "key": "value"\n}')
+      },
+    },
+    'indented-code-fence-with-prior-indented-subcomponent': {
+      // Code fence at containerIndentSize indent should still work correctly —
+      // spaces ARE stripped from the opening line, so content stripping applies too.
+      // The stringify round-trip normalizes the fence back to column 0.
+      markdown: [
+        '::component',
+        '',
+        '  :::nested',
+        '  :::',
+        '',
+        '  ```json',
+        '  {',
+        '    "key": "value"',
+        '  }',
+        '  ```',
+        '::',
+      ].join('\n'),
+      expected: [
+        '::component',
+        '  :::nested',
+        '  :::',
+        '',
+        '```json',
+        '{',
+        '  "key": "value"',
+        '}',
+        '```',
+        '::',
+      ].join('\n'),
+      extra: (_md, ast) => {
+        const container = ast.children[0]
+        const codeNode = container.children[1]
+        expect(codeNode.type).toBe('code')
+        expect(codeNode.value).toBe('{\n  "key": "value"\n}')
+      },
+    },
+    'tilde-code-fence-with-prior-indented-subcomponent': {
+      // Tilde-delimited fences must behave identically to backtick fences:
+      // content indentation must be preserved when the fence is at column 0.
+      markdown: [
+        '::component',
+        '',
+        '  :::nested',
+        '  :::',
+        '',
+        '~~~json',
+        '{',
+        '  "key": "value"',
+        '}',
+        '~~~',
+        '::',
+      ].join('\n'),
+      expected: [
+        '::component',
+        '  :::nested',
+        '  :::',
+        '',
+        '```json',
+        '{',
+        '  "key": "value"',
+        '}',
+        '```',
+        '::',
+      ].join('\n'),
+      extra: (_md, ast) => {
+        const container = ast.children[0]
+        const codeNode = container.children[1]
+        expect(codeNode.type).toBe('code')
+        expect(codeNode.value).toBe('{\n  "key": "value"\n}')
+      },
+    },
+    'tilde-code-fence-blank-line-before': {
+      // Same as tilde-code-fence-with-prior-indented-subcomponent but with a blank
+      // line before the fence, exercising the attemptIntentedCommponent path.
+      markdown: [
+        '::component',
+        '',
+        '  :::nested',
+        '  :::',
+        '',
+        'Some text',
+        '',
+        '~~~json',
+        '{',
+        '  "key": "value"',
+        '}',
+        '~~~',
+        '::',
+      ].join('\n'),
+      expected: [
+        '::component',
+        '  :::nested',
+        '  :::',
+        '',
+        'Some text',
+        '',
+        '```json',
+        '{',
+        '  "key": "value"',
+        '}',
+        '```',
+        '::',
+      ].join('\n'),
+      extra: (_md, ast) => {
+        const container = ast.children[0]
+        // children[0] = nested container, children[1] = paragraph, children[2] = code
+        const codeNode = container.children[2]
+        expect(codeNode.type).toBe('code')
+        expect(codeNode.value).toBe('{\n  "key": "value"\n}')
+      },
+    },
+    'two-code-fences-indented-then-column-zero': {
+      // Second fence (column 0) must not inherit codeFenceStripped from the first
+      // fence (indented), which would incorrectly strip its content indentation.
+      markdown: [
+        '::component',
+        '',
+        '  :::nested',
+        '  :::',
+        '',
+        '  ```json',
+        '  { "first": true }',
+        '  ```',
+        '',
+        '```json',
+        '{',
+        '  "second": true',
+        '}',
+        '```',
+        '::',
+      ].join('\n'),
+      expected: [
+        '::component',
+        '  :::nested',
+        '  :::',
+        '',
+        '```json',
+        '{ "first": true }',
+        '```',
+        '',
+        '```json',
+        '{',
+        '  "second": true',
+        '}',
+        '```',
+        '::',
+      ].join('\n'),
+      extra: (_md, ast) => {
+        const container = ast.children[0]
+        // children[0]=nested, children[1]=first code, children[2]=second code
+        expect(container.children[1].type).toBe('code')
+        expect(container.children[1].value).toBe('{ "first": true }')
+        expect(container.children[2].type).toBe('code')
+        expect(container.children[2].value).toBe('{\n  "second": true\n}')
+      },
+    },
+    'two-code-fences-column-zero-then-indented': {
+      // Reverse order: column-0 fence first, then indented fence. The indented fence
+      // must still have its content stripped correctly.
+      markdown: [
+        '::component',
+        '',
+        '  :::nested',
+        '  :::',
+        '',
+        '```json',
+        '{',
+        '  "first": true',
+        '}',
+        '```',
+        '',
+        '  ```json',
+        '  { "second": true }',
+        '  ```',
+        '::',
+      ].join('\n'),
+      expected: [
+        '::component',
+        '  :::nested',
+        '  :::',
+        '',
+        '```json',
+        '{',
+        '  "first": true',
+        '}',
+        '```',
+        '',
+        '```json',
+        '{ "second": true }',
+        '```',
+        '::',
+      ].join('\n'),
+      extra: (_md, ast) => {
+        const container = ast.children[0]
+        expect(container.children[1].type).toBe('code')
+        expect(container.children[1].value).toBe('{\n  "first": true\n}')
+        expect(container.children[2].type).toBe('code')
+        expect(container.children[2].value).toBe('{ "second": true }')
+      },
+    },
     'dangling-list': {
       markdown: [
         '::component',

--- a/test_detailed.mjs
+++ b/test_detailed.mjs
@@ -1,0 +1,31 @@
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkMdc from './dist/index.mjs'
+
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkMdc)
+
+// More explicit test: the exact scenario mentioned
+const mdBuggyCase = `::component
+~~~
+three backticks inside tilde fence:
+\`\`\`
+~~~
+::`
+
+console.log('=== Potential Bug Case ===')
+console.log('Input:')
+console.log(mdBuggyCase)
+console.log('\nParsing...')
+const ast = processor.parse(mdBuggyCase)
+const container = ast.children[0]
+console.log('Container type:', container.type)
+console.log('Container children count:', container.children.length)
+container.children.forEach((child, i) => {
+  console.log(`  Child ${i}:`)
+  console.log(`    Type: ${child.type}`)
+  console.log(`    Value: ${JSON.stringify(child.value)}`)
+})
+console.log('\nFull AST:')
+console.log(JSON.stringify(ast, null, 2))

--- a/test_mixed_delimiters.js
+++ b/test_mixed_delimiters.js
@@ -1,0 +1,40 @@
+const { unified } = require('unified')
+const remarkParse = require('remark-parse')
+const remarkMdc = require('./dist/index.js').default
+
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkMdc)
+
+// Test case: tilde fence with backticks inside
+const mdWithTildeAndBackticks = `::component
+~~~json
+Here is an example fence:
+\`\`\`
+code
+\`\`\`
+~~~
+::`
+
+const mdWithBacktickAndTildes = `::component
+\`\`\`json
+Here is an example fence:
+~~~
+code
+~~~
+\`\`\`
+::`
+
+console.log('=== Test 1: Tilde fence with backticks inside ===')
+console.log('Input:')
+console.log(mdWithTildeAndBackticks)
+console.log('\nOutput:')
+const ast1 = processor.parse(mdWithTildeAndBackticks)
+console.log(JSON.stringify(ast1, null, 2))
+
+console.log('\n=== Test 2: Backtick fence with tildes inside ===')
+console.log('Input:')
+console.log(mdWithBacktickAndTildes)
+console.log('\nOutput:')
+const ast2 = processor.parse(mdWithBacktickAndTildes)
+console.log(JSON.stringify(ast2, null, 2))

--- a/test_mixed_delimiters.mjs
+++ b/test_mixed_delimiters.mjs
@@ -1,0 +1,56 @@
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkMdc from './dist/index.mjs'
+
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkMdc)
+
+// Test case: tilde fence with backticks inside
+const mdWithTildeAndBackticks = `::component
+~~~json
+Here is an example fence:
+\`\`\`
+code
+\`\`\`
+~~~
+::`
+
+const mdWithBacktickAndTildes = `::component
+\`\`\`json
+Here is an example fence:
+~~~
+code
+~~~
+\`\`\`
+::`
+
+console.log('=== Test 1: Tilde fence with backticks inside ===')
+console.log('Input:')
+console.log(mdWithTildeAndBackticks)
+console.log('\nParsing...')
+try {
+  const ast1 = processor.parse(mdWithTildeAndBackticks)
+  const container = ast1.children[0]
+  console.log('Container children:', container.children.length)
+  container.children.forEach((child, i) => {
+    console.log(`  ${i}: ${child.type}`, child.value ? `(${child.value.substring(0, 50)})` : '')
+  })
+} catch (e) {
+  console.error('Error:', e.message)
+}
+
+console.log('\n=== Test 2: Backtick fence with tildes inside ===')
+console.log('Input:')
+console.log(mdWithBacktickAndTildes)
+console.log('\nParsing...')
+try {
+  const ast2 = processor.parse(mdWithBacktickAndTildes)
+  const container = ast2.children[0]
+  console.log('Container children:', container.children.length)
+  container.children.forEach((child, i) => {
+    console.log(`  ${i}: ${child.type}`, child.value ? `(${child.value.substring(0, 50)})` : '')
+  })
+} catch (e) {
+  console.error('Error:', e.message)
+}

--- a/test_mixed_delimiters.mjs
+++ b/test_mixed_delimiters.mjs
@@ -36,7 +36,8 @@ try {
   container.children.forEach((child, i) => {
     console.log(`  ${i}: ${child.type}`, child.value ? `(${child.value.substring(0, 50)})` : '')
   })
-} catch (e) {
+}
+catch (e) {
   console.error('Error:', e.message)
 }
 
@@ -51,6 +52,7 @@ try {
   container.children.forEach((child, i) => {
     console.log(`  ${i}: ${child.type}`, child.value ? `(${child.value.substring(0, 50)})` : '')
   })
-} catch (e) {
+}
+catch (e) {
   console.error('Error:', e.message)
 }


### PR DESCRIPTION
## Summary

> [!NOTE]
> @farnabaz this will need to be picked up in [@nuxtjs/mdc](https://github.com/nuxt-content/mdc) once verified and released. 

Fixes a bug where a fenced code block at column 0 inside a MDC block component had its content indentation stripped when an indented child component appeared earlier in the same container block.

Resolves https://github.com/nuxt-content/mdc/issues/483


### Reproduction

Paste the following into the https://github.com/nuxt-content/mdc playground (dev server)


````md
::container

  ::container
  ---
  foo: "bar"
  ---
  ::

```json
{
  "labore": "set dolore",
  "magna": "aliqua",
  "veniam": true
}
```

::
````

<img width="477" height="189" alt="image" src="https://github.com/user-attachments/assets/c3532da7-314d-4c3d-b579-ad89cfd8cfe3" />


The `::container` at 2-space indent causes the tokenizer to set `containerIndentSize = 2`. From that point on, `dentendIndentedCommponent` and `attemptIntentedCommponent` were unconditionally calling `factorySpace` to strip up to `containerIndentSize + 1` spaces from every subsequent line, including lines inside a code fence that was opened at column 0. The guard against `visitingCodeFenced` happened inside `lineStartAfterPrefix`, which is called *after* the spaces were already consumed.

### Fix

Track whether the current fence's opening line itself had spaces stripped (`codeFenceStripped`).
  
When `visitingCodeFenced && !codeFenceStripped`, skip the `factorySpace` call entirely so code content at column 0 is passed through untouched. Fences opened at `containerIndentSize` indent (e.g. yaml props blocks) continue to work correctly since their opening lines do go through stripping.
