### PR TITLE
chore: migrate to pnpm 11 and use allowBuilds

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-shamefully-hoist=true
-strict-peer-dependencies=false

--- a/package.json
+++ b/package.json
@@ -83,5 +83,5 @@
       "after:bump": "npx changelogen@latest --no-commit --no-tag --output --r $(node -p \"require('./package.json').version\")"
     }
   },
-  "packageManager": "pnpm@10.26.2"
+  "packageManager": "pnpm@11.1.3"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,9 @@ packages:
   - ./
   - playground
 
+shamefullyHoist: true
+strictPeerDependencies: false
+
 allowBuilds:
   '@parcel/watcher': false
   '@tailwindcss/oxide': true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,8 +2,9 @@ packages:
   - ./
   - playground
 
-onlyBuiltDependencies:
-  - '@tailwindcss/oxide'
-  - esbuild
-  - unrs-resolver
-  - vue-demi
+allowBuilds:
+  '@parcel/watcher': false
+  '@tailwindcss/oxide': true
+  esbuild: true
+  unrs-resolver: true
+  vue-demi: true


### PR DESCRIPTION
Migrate to pnpm 11. Two related changes: (1) `pnpm-workspace.yaml` switches from `onlyBuiltDependencies` to the new `allowBuilds` map (`@parcel/watcher` set to `false` to preserve prior ignored-builds behavior); (2) `shamefullyHoist` and `strictPeerDependencies` move from `.npmrc` to `pnpm-workspace.yaml` since pnpm 11 only reads auth/registry settings from `.npmrc` — without this, `typescript` wasn't hoisted and `pnpm lint` regressed.