### PR TITLE
fix: reset chunk link between slots to preserve list structure

### DIFF
--- a/src/micromark-extension/tokenize-container.ts
+++ b/src/micromark-extension/tokenize-container.ts
@@ -109,7 +109,8 @@ function tokenize(this: TokenizeContext, effects: Effects, ok: State, nok: State
   }
 
   function sectionOpen(code: Code): undefined | State {
-    // Open new Section
+    // Open new Section — reset chunk link so each slot gets its own document context.
+    previous = undefined
     section.enter(effects)
 
     if (markdownLineEnding(code)) {

--- a/test/__snapshots__/block-component.test.ts.snap
+++ b/test/__snapshots__/block-component.test.ts.snap
@@ -696,9 +696,9 @@ exports[`block-component > dangling-list 1`] = `
               ],
               "position": {
                 "end": {
-                  "column": 6,
-                  "line": 5,
-                  "offset": 42,
+                  "column": 12,
+                  "line": 3,
+                  "offset": 35,
                 },
                 "start": {
                   "column": 1,
@@ -706,16 +706,16 @@ exports[`block-component > dangling-list 1`] = `
                   "offset": 24,
                 },
               },
-              "spread": true,
+              "spread": false,
               "type": "listItem",
             },
           ],
           "ordered": false,
           "position": {
             "end": {
-              "column": 6,
-              "line": 5,
-              "offset": 42,
+              "column": 12,
+              "line": 3,
+              "offset": 35,
             },
             "start": {
               "column": 1,
@@ -1727,6 +1727,453 @@ exports[`block-component > jsonScapeAttr 1`] = `
       "column": 3,
       "line": 2,
       "offset": 40,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block-component > multiple-slots-with-lists 1`] = `
+{
+  "children": [
+    {
+      "attributes": {},
+      "children": [
+        {
+          "attributes": {},
+          "children": [
+            {
+              "children": [
+                {
+                  "checked": null,
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "position": {
+                            "end": {
+                              "column": 11,
+                              "line": 4,
+                              "offset": 31,
+                            },
+                            "start": {
+                              "column": 3,
+                              "line": 4,
+                              "offset": 23,
+                            },
+                          },
+                          "type": "text",
+                          "value": "item one",
+                        },
+                      ],
+                      "position": {
+                        "end": {
+                          "column": 11,
+                          "line": 4,
+                          "offset": 31,
+                        },
+                        "start": {
+                          "column": 3,
+                          "line": 4,
+                          "offset": 23,
+                        },
+                      },
+                      "type": "paragraph",
+                    },
+                  ],
+                  "position": {
+                    "end": {
+                      "column": 11,
+                      "line": 4,
+                      "offset": 31,
+                    },
+                    "start": {
+                      "column": 1,
+                      "line": 4,
+                      "offset": 21,
+                    },
+                  },
+                  "spread": false,
+                  "type": "listItem",
+                },
+                {
+                  "checked": null,
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "position": {
+                            "end": {
+                              "column": 11,
+                              "line": 5,
+                              "offset": 42,
+                            },
+                            "start": {
+                              "column": 3,
+                              "line": 5,
+                              "offset": 34,
+                            },
+                          },
+                          "type": "text",
+                          "value": "item two",
+                        },
+                      ],
+                      "position": {
+                        "end": {
+                          "column": 11,
+                          "line": 5,
+                          "offset": 42,
+                        },
+                        "start": {
+                          "column": 3,
+                          "line": 5,
+                          "offset": 34,
+                        },
+                      },
+                      "type": "paragraph",
+                    },
+                  ],
+                  "position": {
+                    "end": {
+                      "column": 11,
+                      "line": 5,
+                      "offset": 42,
+                    },
+                    "start": {
+                      "column": 1,
+                      "line": 5,
+                      "offset": 32,
+                    },
+                  },
+                  "spread": false,
+                  "type": "listItem",
+                },
+                {
+                  "checked": null,
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "position": {
+                            "end": {
+                              "column": 13,
+                              "line": 6,
+                              "offset": 55,
+                            },
+                            "start": {
+                              "column": 3,
+                              "line": 6,
+                              "offset": 45,
+                            },
+                          },
+                          "type": "text",
+                          "value": "item three",
+                        },
+                      ],
+                      "position": {
+                        "end": {
+                          "column": 13,
+                          "line": 6,
+                          "offset": 55,
+                        },
+                        "start": {
+                          "column": 3,
+                          "line": 6,
+                          "offset": 45,
+                        },
+                      },
+                      "type": "paragraph",
+                    },
+                  ],
+                  "position": {
+                    "end": {
+                      "column": 13,
+                      "line": 6,
+                      "offset": 55,
+                    },
+                    "start": {
+                      "column": 1,
+                      "line": 6,
+                      "offset": 43,
+                    },
+                  },
+                  "spread": false,
+                  "type": "listItem",
+                },
+              ],
+              "ordered": false,
+              "position": {
+                "end": {
+                  "column": 13,
+                  "line": 6,
+                  "offset": 55,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 4,
+                  "offset": 21,
+                },
+              },
+              "spread": false,
+              "start": null,
+              "type": "list",
+            },
+          ],
+          "data": {
+            "hName": "component-slot",
+            "hProperties": {
+              "v-slot:slot-a": "",
+            },
+          },
+          "name": "slot-a",
+          "position": {
+            "end": {
+              "column": 1,
+              "line": 8,
+              "offset": 57,
+            },
+            "start": {
+              "column": 2,
+              "line": 3,
+              "offset": 14,
+            },
+          },
+          "type": "componentContainerSection",
+        },
+        {
+          "attributes": {},
+          "children": [
+            {
+              "children": [
+                {
+                  "checked": null,
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "position": {
+                            "end": {
+                              "column": 11,
+                              "line": 9,
+                              "offset": 75,
+                            },
+                            "start": {
+                              "column": 3,
+                              "line": 9,
+                              "offset": 67,
+                            },
+                          },
+                          "type": "text",
+                          "value": "item one",
+                        },
+                      ],
+                      "position": {
+                        "end": {
+                          "column": 11,
+                          "line": 9,
+                          "offset": 75,
+                        },
+                        "start": {
+                          "column": 3,
+                          "line": 9,
+                          "offset": 67,
+                        },
+                      },
+                      "type": "paragraph",
+                    },
+                  ],
+                  "position": {
+                    "end": {
+                      "column": 11,
+                      "line": 9,
+                      "offset": 75,
+                    },
+                    "start": {
+                      "column": 1,
+                      "line": 9,
+                      "offset": 65,
+                    },
+                  },
+                  "spread": false,
+                  "type": "listItem",
+                },
+                {
+                  "checked": null,
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "position": {
+                            "end": {
+                              "column": 11,
+                              "line": 10,
+                              "offset": 86,
+                            },
+                            "start": {
+                              "column": 3,
+                              "line": 10,
+                              "offset": 78,
+                            },
+                          },
+                          "type": "text",
+                          "value": "item two",
+                        },
+                      ],
+                      "position": {
+                        "end": {
+                          "column": 11,
+                          "line": 10,
+                          "offset": 86,
+                        },
+                        "start": {
+                          "column": 3,
+                          "line": 10,
+                          "offset": 78,
+                        },
+                      },
+                      "type": "paragraph",
+                    },
+                  ],
+                  "position": {
+                    "end": {
+                      "column": 11,
+                      "line": 10,
+                      "offset": 86,
+                    },
+                    "start": {
+                      "column": 1,
+                      "line": 10,
+                      "offset": 76,
+                    },
+                  },
+                  "spread": false,
+                  "type": "listItem",
+                },
+                {
+                  "checked": null,
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "position": {
+                            "end": {
+                              "column": 13,
+                              "line": 11,
+                              "offset": 99,
+                            },
+                            "start": {
+                              "column": 3,
+                              "line": 11,
+                              "offset": 89,
+                            },
+                          },
+                          "type": "text",
+                          "value": "item three",
+                        },
+                      ],
+                      "position": {
+                        "end": {
+                          "column": 13,
+                          "line": 11,
+                          "offset": 99,
+                        },
+                        "start": {
+                          "column": 3,
+                          "line": 11,
+                          "offset": 89,
+                        },
+                      },
+                      "type": "paragraph",
+                    },
+                  ],
+                  "position": {
+                    "end": {
+                      "column": 13,
+                      "line": 11,
+                      "offset": 99,
+                    },
+                    "start": {
+                      "column": 1,
+                      "line": 11,
+                      "offset": 87,
+                    },
+                  },
+                  "spread": false,
+                  "type": "listItem",
+                },
+              ],
+              "ordered": false,
+              "position": {
+                "end": {
+                  "column": 13,
+                  "line": 11,
+                  "offset": 99,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 9,
+                  "offset": 65,
+                },
+              },
+              "spread": false,
+              "start": null,
+              "type": "list",
+            },
+          ],
+          "data": {
+            "hName": "component-slot",
+            "hProperties": {
+              "v-slot:slot-b": "",
+            },
+          },
+          "name": "slot-b",
+          "position": {
+            "end": {
+              "column": 3,
+              "line": 13,
+              "offset": 103,
+            },
+            "start": {
+              "column": 2,
+              "line": 8,
+              "offset": 58,
+            },
+          },
+          "type": "componentContainerSection",
+        },
+      ],
+      "data": {
+        "hName": "component",
+        "hProperties": {},
+      },
+      "fmAttributes": {},
+      "name": "component",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 13,
+          "offset": 103,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "rawData": undefined,
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 13,
+      "offset": 103,
     },
     "start": {
       "column": 1,

--- a/test/block-component.test.ts
+++ b/test/block-component.test.ts
@@ -524,6 +524,45 @@ describe('block-component', () => {
         '::',
       ].join('\n'),
     },
+    'multiple-slots-with-lists': {
+      markdown: [
+        '::component',
+        '',
+        '#slot-a',
+        '- item one',
+        '- item two',
+        '- item three',
+        '',
+        '#slot-b',
+        '- item one',
+        '- item two',
+        '- item three',
+        '',
+        '::',
+      ].join('\n'),
+      expected: [
+        '::component',
+        '#slot-a',
+        '- item one',
+        '- item two',
+        '- item three',
+        '',
+        '#slot-b',
+        '- item one',
+        '- item two',
+        '- item three',
+        '::',
+      ].join('\n'),
+      extra(_md, ast) {
+        const container = ast.children[0]
+        const slotA = container.children.find((c: any) => c.name === 'slot-a')
+        const slotB = container.children.find((c: any) => c.name === 'slot-b')
+        expect(slotA.children[0].type).toBe('list')
+        expect(slotB.children[0].type).toBe('list')
+        expect(slotA.children[0].children).toHaveLength(3)
+        expect(slotB.children[0].children).toHaveLength(3)
+      },
+    },
     'trim-slot-name': {
       markdown: [
         '::component',


### PR DESCRIPTION
When multiple named slots each contain a list, the second slot's children were missing the `list` wrapper node — list items appeared as direct children of the `componentContainerSection`.

originally reported in nuxt/content#3803