### PR TITLE
feat: block-level attributes and single-child block component fold

### DIFF
--- a/docs/content/0.index.md
+++ b/docs/content/0.index.md
@@ -197,6 +197,46 @@ There are also a couple of sugar syntaxes for common use-cases:
 - No value (boolean props): `:component{no-border}`
 - Single string without any space: `**bold**{class=red}`
 
+A trailing props scope also attaches to the nearest **block** element. This works for paragraphs, headings, list items and blockquote paragraphs:
+
+```md
+A paragraph {style="color: red"}
+
+# Heading {#the-heading}
+
+- a list item {.highlight}
+- another list item {.muted}
+
+1. an ordered item {data-step="1"}
+
+- [ ] a task {.todo}
+
+> A blockquote {.note}
+```
+
+The props are only lifted to the block when they sit at the very end of the line. A scope that is followed by more text (`A {x} paragraph`) stays literal, and a scope right after an inline element keeps attaching to that element (`**bold**{.x}` targets the `<strong>`).
+
+For list-, table- and multi-paragraph-blockquote-level attributes — which have no native trailing syntax — use the matching `::ul` / `::ol` / `::table` / `::blockquote` block component. When one of these wraps a single same-tagged child, it is folded into that element and its attributes are applied directly to it:
+
+```md
+::ul{.menu}
+- item 1
+- item 2
+::
+
+::table{.striped}
+| a | b |
+| - | - |
+| 1 | 2 |
+::
+
+::blockquote{.note}
+> First paragraph
+>
+> Second paragraph
+::
+```
+
 If you want to pass arrays or objects as props to components, you can pass them as a JSON string and prefix the prop key with a colon to automatically decode the JSON string. Note that in this case, you should use single quotes for the value string so you can use double quotes to pass a valid JSON string:
 
 ```md

--- a/src/from-markdown.ts
+++ b/src/from-markdown.ts
@@ -46,6 +46,15 @@ export default (opts: RemarkMDCOptions = {}) => {
       return
     }
 
+    // Lift the unwrapped paragraph's trailing attributes onto the parent so
+    // they survive the paragraph being removed. Parent attributes win.
+    if ((child as any).attributes && Object.keys((child as any).attributes).length) {
+      (node as any).attributes = {
+        ...(child as any).attributes,
+        ...((node as any).attributes || {}),
+      }
+    }
+
     const childIndex = node.children.indexOf(child)
 
     node.children.splice(childIndex, 1, ...((child as Container)?.children || []))
@@ -156,6 +165,14 @@ export default (opts: RemarkMDCOptions = {}) => {
           container.mdc = container.mdc || {}
           container.mdc.unwrapped = child.mdc?.unwrapped
         }
+        // Lift attributes gathered while unwrapping the default slot's
+        // paragraph onto the container. Container attributes win.
+        if (child.attributes && Object.keys(child.attributes).length) {
+          (container as any).attributes = {
+            ...child.attributes,
+            ...((container as any).attributes || {}),
+          }
+        }
         return child.children
       }
       child.data = {
@@ -169,6 +186,50 @@ export default (opts: RemarkMDCOptions = {}) => {
     })
 
     this.exit(token)
+
+    // Fold `::ul` / `::ol` / `::table` / `::blockquote` into their single
+    // same-tagged child so the wrapper's attributes land on the actual
+    // element instead of producing a redundant nested duplicate.
+    const folded = foldSingleTagChild(container)
+    if (folded) {
+      const parent = this.stack[this.stack.length - 1] as Container
+      const index = parent?.children?.indexOf(container as any)
+      if (parent && index !== undefined && index > -1) {
+        parent.children[index] = folded as any
+      }
+    }
+  }
+
+  function foldSingleTagChild(container: Container): Nodes | undefined {
+    const matchers: Record<string, (child: any) => boolean> = {
+      ul: child => child.type === 'list' && !child.ordered,
+      ol: child => child.type === 'list' && child.ordered,
+      table: child => child.type === 'table',
+      blockquote: child => child.type === 'blockquote',
+    }
+    const matches = matchers[(container as any).name]
+    if (!matches) {
+      return
+    }
+    // Keep the nested form when the wrapper carries frontmatter data so those
+    // attributes aren't silently lost (they're bound later on the component).
+    if (container.rawData) {
+      return
+    }
+    if (container.children.length !== 1) {
+      return
+    }
+    const child = container.children[0] as any
+    if (!matches(child)) {
+      return
+    }
+
+    // Merge the wrapper's attributes onto the child; outer attributes win.
+    const outer = (container as any).attributes || {}
+    if (Object.keys(outer).length || child.attributes) {
+      child.attributes = { ...(child.attributes || {}), ...outer }
+    }
+    return child as Nodes
   }
 
   function enterContainerSection(this: CompileContext, token: Token) {
@@ -295,11 +356,30 @@ export default (opts: RemarkMDCOptions = {}) => {
     (this.data as any).componentAttributes = attributes
     this.resume() // Drop EOLs
 
-    let stackTop = this.stack[this.stack.length - 1]
+    const block = this.stack[this.stack.length - 1]
+    let stackTop = block
 
     if (stackTop?.type !== 'textComponent' || stackTop?.name === 'span') {
       while (!stackTop?.position?.end && (stackTop as Container).children?.length > 0) {
         stackTop = (stackTop as Container).children[(stackTop as Container).children.length - 1]!
+      }
+    }
+
+    // When the attributes trail a plain text node they don't belong to any
+    // inline element — attach them to the nearest block element instead.
+    if (stackTop?.type === 'text') {
+      // Drop the separating whitespace before `{` from the text; the
+      // stringifier re-adds it when emitting the trailing attributes.
+      (stackTop as any).value = String((stackTop as any).value || '').replace(/[ \t]+$/, '')
+
+      stackTop = block
+      // A paragraph that is the content of a list item: the attributes belong
+      // to the list item, not the inner paragraph.
+      if (block?.type === 'paragraph') {
+        const parent = this.stack[this.stack.length - 2]
+        if (parent?.type === 'listItem') {
+          stackTop = parent
+        }
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,28 @@ export default <Plugin<Array<RemarkMDCOptions>>> function remarkMDC(opts: Remark
 
   add('micromarkExtensions', syntax())
   add('fromMarkdownExtensions', fromMarkdown(opts))
-  add('toMarkdownExtensions', toMarkdown(opts))
+  // Capture `table` / `listItem` serializers from extensions registered before
+  // us (e.g. remark-gfm) so we can compose with them when emitting block-level
+  // attributes instead of clobbering their output.
+  const findToMarkdownHandler = (name: string, extensions: any = data['toMarkdownExtensions'], seen = new Set()): any => {
+    for (const ext of ([] as any[]).concat(extensions || [])) {
+      if (!ext || typeof ext !== 'object' || seen.has(ext)) {
+        continue
+      }
+      seen.add(ext)
+      if (ext.handlers?.[name]) {
+        return ext.handlers[name]
+      }
+      const nested = findToMarkdownHandler(name, ext.extensions, seen)
+      if (nested) {
+        return nested
+      }
+    }
+  }
+  add('toMarkdownExtensions', toMarkdown(opts, {
+    table: findToMarkdownHandler('table'),
+    listItem: findToMarkdownHandler('listItem'),
+  }))
 
   function add(field: string, value: any) {
     /* istanbul ignore if - other extensions. */

--- a/src/micromark-extension/tokenize-attribute.ts
+++ b/src/micromark-extension/tokenize-attribute.ts
@@ -4,6 +4,7 @@ import { Codes } from './constants'
 import createAttributes from './factory-attributes'
 
 const attributes: any = { tokenize: tokenizeAttributes, partial: true }
+const blockAttributes: any = { tokenize: tokenizeBlockAttributes, partial: true }
 
 const validEvents = [
   /**
@@ -43,11 +44,38 @@ function tokenize(this: TokenizeContext, effects: Effects, ok: State, nok: State
      * Make sure syntax is used after valid tags
      */
     const event = self.events[self.events.length - 1]
-    if (markdownLineEnding(self.previous) || !event || !validEvents.includes(event[1].type)) {
+    if (markdownLineEnding(self.previous) || !event) {
       return nok(code)
     }
 
-    return effects.attempt(attributes, ok, nok)(code)
+    if (validEvents.includes(event[1].type)) {
+      return effects.attempt(attributes, ok, nok)(code)
+    }
+
+    /**
+     * Trailing block attributes: `{attr}` following plain text at the end of a
+     * block (paragraph, heading, list item, blockquote paragraph). Only accept
+     * when the attributes are the last thing on the line so that `{...}` in the
+     * middle of some text stays literal.
+     */
+    if (event[1].type === 'data') {
+      return effects.attempt(blockAttributes, ok, nok)(code)
+    }
+
+    return nok(code)
+  }
+}
+
+function tokenizeBlockAttributes(this: TokenizeContext, effects: Effects, ok: State, nok: State) {
+  // Always a `{`. Reuse the regular attributes factory, but only succeed when
+  // the closing `}` is immediately followed by the end of the line (or input).
+  return tokenizeAttributes(effects, afterAttributes, nok)
+
+  function afterAttributes(code: Code): State | undefined {
+    if (code === Codes.EOF || markdownLineEnding(code)) {
+      return ok(code)
+    }
+    return nok(code)
   }
 }
 

--- a/src/to-markdown.ts
+++ b/src/to-markdown.ts
@@ -36,7 +36,12 @@ function compilePattern(pattern: Unsafe) {
 
 type NodeComponentContainerSection = Parents & { name: string }
 
-export default (opts: RemarkMDCOptions = {}) => {
+interface ComposedHandlers {
+  table?: (node: any, parent: any, state: State, info: Info) => string
+  listItem?: (node: any, parent: any, state: State, info: Info) => string
+}
+
+export default (opts: RemarkMDCOptions = {}, composed: ComposedHandlers = {}) => {
   const applyAutomaticUnwrap = (node: Container, _options: Exclude<RemarkMDCOptions['autoUnwrap'], boolean | undefined>) => {
     if (!CONTAINER_NODE_TYPES.has(node.type)) {
       // unwrap only applicable for container components
@@ -312,6 +317,37 @@ export default (opts: RemarkMDCOptions = {}) => {
     return node.children && node.children[0] && node.children[0].data && node.children[0].data.componentLabel
   }
 
+  // User-facing attributes on a plain block node (paragraph, heading, list, …),
+  // ignoring the `__order__` bookkeeping key used by `preserveOrder`.
+  function hasUserAttributes(node: any) {
+    const attrs = node?.attributes
+    return !!attrs && Object.keys(attrs).some(key => key !== '__order__')
+  }
+
+  // Trailing `{attr=…}` suffix for a block element, separated by a space.
+  function attributesSuffix(node: any, context: State) {
+    if (!hasUserAttributes(node)) {
+      return ''
+    }
+    const text = attributes(node, context)
+    return text ? ' ' + text : ''
+  }
+
+  // Re-wrap a folded `list` / `table` / `blockquote` carrying user attributes in
+  // its matching `::tag{attrs}` block component for serialization.
+  function wrapBlock(name: string, node: any, context: State) {
+    const inner = { ...node }
+    delete inner.attributes
+    const wrapper = {
+      type: 'containerComponent',
+      name,
+      attributes: node.attributes,
+      fmAttributes: {},
+      children: [inner],
+    }
+    return containerComponent(wrapper as any, null, context)
+  }
+
   return {
     compilePattern,
     unsafe: [
@@ -335,6 +371,47 @@ export default (opts: RemarkMDCOptions = {}) => {
       containerComponent,
       textComponent,
       componentContainerSection,
+      paragraph: (node: Parents, _: any, state: State, info: Info) => {
+        return defaultHandlers.paragraph(node as any, _, state, info) + attributesSuffix(node, state)
+      },
+      heading: (node: Parents, _: any, state: State, info: Info) => {
+        return defaultHandlers.heading(node as any, _, state, info) + attributesSuffix(node, state)
+      },
+      listItem: (node: Parents, parent: any, state: State, info: Info) => {
+        const handle = composed.listItem || defaultHandlers.listItem
+        return handle(node as any, parent, state, info) + attributesSuffix(node, state)
+      },
+      list: (node: Parents, parent: any, state: State, info: Info) => {
+        if (hasUserAttributes(node)) {
+          return wrapBlock((node as any).ordered ? 'ol' : 'ul', node, state)
+        }
+        return defaultHandlers.list(node as any, parent, state, info)
+      },
+      blockquote: (node: Parents, parent: any, state: State, info: Info) => {
+        if (hasUserAttributes(node)) {
+          // Multi-block blockquotes have no natural slot for attributes, so use
+          // the `::blockquote{attrs}` wrapper. Single-content blockquotes keep
+          // the natural `> text {attr}` form by moving the attrs to the child.
+          if (node.children.length > 1) {
+            return wrapBlock('blockquote', node, state)
+          }
+          const child = node.children[0] as any
+          const inner = { ...child, attributes: { ...(child?.attributes || {}), ...(node as any).attributes } }
+          const clone = { ...node, attributes: undefined, children: [inner] }
+          return defaultHandlers.blockquote(clone as any, parent, state, info)
+        }
+        return defaultHandlers.blockquote(node as any, parent, state, info)
+      },
+      ...(composed.table
+        ? {
+            table: (node: Parents, parent: any, state: State, info: Info) => {
+              if (hasUserAttributes(node)) {
+                return wrapBlock('table', node, state)
+              }
+              return composed.table!(node as any, parent, state, info)
+            },
+          }
+        : {}),
       image: (node: Parents, _: any, state: State, info: Info) => {
         return defaultHandlers.image(node as any, _, state, info) + attributes(node, state)
       },

--- a/test/__snapshots__/block-attributes.test.ts.snap
+++ b/test/__snapshots__/block-attributes.test.ts.snap
@@ -1,0 +1,1852 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`block attributes > blockquote 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "attributes": {
+            "attr": "value",
+          },
+          "children": [
+            {
+              "position": {
+                "end": {
+                  "column": 14,
+                  "line": 1,
+                  "offset": 13,
+                },
+                "start": {
+                  "column": 3,
+                  "line": 1,
+                  "offset": 2,
+                },
+              },
+              "type": "text",
+              "value": "Blockquote",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 28,
+              "line": 1,
+              "offset": 27,
+            },
+            "start": {
+              "column": 3,
+              "line": 1,
+              "offset": 2,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "position": {
+        "end": {
+          "column": 28,
+          "line": 1,
+          "offset": 27,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "blockquote",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 28,
+      "line": 1,
+      "offset": 27,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block attributes > blockquote multiple paragraphs 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "attributes": {
+            "attr": "value",
+          },
+          "children": [
+            {
+              "position": {
+                "end": {
+                  "column": 10,
+                  "line": 1,
+                  "offset": 9,
+                },
+                "start": {
+                  "column": 3,
+                  "line": 1,
+                  "offset": 2,
+                },
+              },
+              "type": "text",
+              "value": "Para 1",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 24,
+              "line": 1,
+              "offset": 23,
+            },
+            "start": {
+              "column": 3,
+              "line": 1,
+              "offset": 2,
+            },
+          },
+          "type": "paragraph",
+        },
+        {
+          "attributes": {
+            "attr2": "value2",
+          },
+          "children": [
+            {
+              "position": {
+                "end": {
+                  "column": 10,
+                  "line": 3,
+                  "offset": 35,
+                },
+                "start": {
+                  "column": 3,
+                  "line": 3,
+                  "offset": 28,
+                },
+              },
+              "type": "text",
+              "value": "Para 2",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 26,
+              "line": 3,
+              "offset": 51,
+            },
+            "start": {
+              "column": 3,
+              "line": 3,
+              "offset": 28,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "position": {
+        "end": {
+          "column": 26,
+          "line": 3,
+          "offset": 51,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "blockquote",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 26,
+      "line": 3,
+      "offset": 51,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block attributes > bullet list items 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "attributes": {
+            "attr": "value",
+          },
+          "checked": null,
+          "children": [
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 15,
+                      "line": 1,
+                      "offset": 14,
+                    },
+                    "start": {
+                      "column": 3,
+                      "line": 1,
+                      "offset": 2,
+                    },
+                  },
+                  "type": "text",
+                  "value": "a list item",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 29,
+                  "line": 1,
+                  "offset": 28,
+                },
+                "start": {
+                  "column": 3,
+                  "line": 1,
+                  "offset": 2,
+                },
+              },
+              "type": "paragraph",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 29,
+              "line": 1,
+              "offset": 28,
+            },
+            "start": {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "spread": false,
+          "type": "listItem",
+        },
+        {
+          "attributes": {
+            "attr2": "value2",
+          },
+          "checked": null,
+          "children": [
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 21,
+                      "line": 2,
+                      "offset": 49,
+                    },
+                    "start": {
+                      "column": 3,
+                      "line": 2,
+                      "offset": 31,
+                    },
+                  },
+                  "type": "text",
+                  "value": "another list item",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 37,
+                  "line": 2,
+                  "offset": 65,
+                },
+                "start": {
+                  "column": 3,
+                  "line": 2,
+                  "offset": 31,
+                },
+              },
+              "type": "paragraph",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 37,
+              "line": 2,
+              "offset": 65,
+            },
+            "start": {
+              "column": 1,
+              "line": 2,
+              "offset": 29,
+            },
+          },
+          "spread": false,
+          "type": "listItem",
+        },
+      ],
+      "ordered": false,
+      "position": {
+        "end": {
+          "column": 37,
+          "line": 2,
+          "offset": 65,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "spread": false,
+      "start": null,
+      "type": "list",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 37,
+      "line": 2,
+      "offset": 65,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block attributes > heading h1 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        "attr": "value",
+      },
+      "children": [
+        {
+          "position": {
+            "end": {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+            "start": {
+              "column": 3,
+              "line": 1,
+              "offset": 2,
+            },
+          },
+          "type": "text",
+          "value": "h1",
+        },
+      ],
+      "depth": 1,
+      "position": {
+        "end": {
+          "column": 20,
+          "line": 1,
+          "offset": 19,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "heading",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 20,
+      "line": 1,
+      "offset": 19,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block attributes > heading h6 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        "attr": "value",
+      },
+      "children": [
+        {
+          "position": {
+            "end": {
+              "column": 11,
+              "line": 1,
+              "offset": 10,
+            },
+            "start": {
+              "column": 8,
+              "line": 1,
+              "offset": 7,
+            },
+          },
+          "type": "text",
+          "value": "h6",
+        },
+      ],
+      "depth": 6,
+      "position": {
+        "end": {
+          "column": 25,
+          "line": 1,
+          "offset": 24,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "heading",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 25,
+      "line": 1,
+      "offset": 24,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block attributes > keeps attaching to inline element 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "attributes": {
+            "attr": "value",
+          },
+          "children": [
+            {
+              "position": {
+                "end": {
+                  "column": 7,
+                  "line": 1,
+                  "offset": 6,
+                },
+                "start": {
+                  "column": 3,
+                  "line": 1,
+                  "offset": 2,
+                },
+              },
+              "type": "text",
+              "value": "bold",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 9,
+              "line": 1,
+              "offset": 8,
+            },
+            "start": {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "strong",
+        },
+        {
+          "position": {
+            "end": {
+              "column": 32,
+              "line": 1,
+              "offset": 31,
+            },
+            "start": {
+              "column": 23,
+              "line": 1,
+              "offset": 22,
+            },
+          },
+          "type": "text",
+          "value": " and more",
+        },
+      ],
+      "position": {
+        "end": {
+          "column": 32,
+          "line": 1,
+          "offset": 31,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 32,
+      "line": 1,
+      "offset": 31,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block attributes > lifts attributes onto unwrapped container 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        "attr": "value",
+      },
+      "children": [
+        {
+          "position": {
+            "end": {
+              "column": 7,
+              "line": 2,
+              "offset": 13,
+            },
+            "start": {
+              "column": 1,
+              "line": 2,
+              "offset": 7,
+            },
+          },
+          "type": "text",
+          "value": "Hello",
+        },
+      ],
+      "data": {
+        "hName": "test",
+        "hProperties": {
+          "attr": "value",
+        },
+      },
+      "fmAttributes": {},
+      "name": "test",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 3,
+          "offset": 30,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 3,
+      "offset": 30,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block attributes > non-trailing attributes stay literal 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "position": {
+            "end": {
+              "column": 16,
+              "line": 1,
+              "offset": 15,
+            },
+            "start": {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "A {x} paragraph",
+        },
+      ],
+      "position": {
+        "end": {
+          "column": 16,
+          "line": 1,
+          "offset": 15,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 16,
+      "line": 1,
+      "offset": 15,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block attributes > ordered list item 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "attributes": {
+            "attr": "value",
+          },
+          "checked": null,
+          "children": [
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 14,
+                      "line": 1,
+                      "offset": 13,
+                    },
+                    "start": {
+                      "column": 4,
+                      "line": 1,
+                      "offset": 3,
+                    },
+                  },
+                  "type": "text",
+                  "value": "List item",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 28,
+                  "line": 1,
+                  "offset": 27,
+                },
+                "start": {
+                  "column": 4,
+                  "line": 1,
+                  "offset": 3,
+                },
+              },
+              "type": "paragraph",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 28,
+              "line": 1,
+              "offset": 27,
+            },
+            "start": {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "spread": false,
+          "type": "listItem",
+        },
+      ],
+      "ordered": true,
+      "position": {
+        "end": {
+          "column": 28,
+          "line": 1,
+          "offset": 27,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "spread": false,
+      "start": 1,
+      "type": "list",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 28,
+      "line": 1,
+      "offset": 27,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block attributes > paragraph 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        "attr": "value",
+      },
+      "children": [
+        {
+          "position": {
+            "end": {
+              "column": 13,
+              "line": 1,
+              "offset": 12,
+            },
+            "start": {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "A paragraph",
+        },
+      ],
+      "position": {
+        "end": {
+          "column": 27,
+          "line": 1,
+          "offset": 26,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 27,
+      "line": 1,
+      "offset": 26,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block attributes > task list items 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "attributes": {
+            "attr": "value",
+          },
+          "checked": false,
+          "children": [
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 22,
+                      "line": 1,
+                      "offset": 21,
+                    },
+                    "start": {
+                      "column": 7,
+                      "line": 1,
+                      "offset": 6,
+                    },
+                  },
+                  "type": "text",
+                  "value": "Task list item",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 36,
+                  "line": 1,
+                  "offset": 35,
+                },
+                "start": {
+                  "column": 7,
+                  "line": 1,
+                  "offset": 6,
+                },
+              },
+              "type": "paragraph",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 36,
+              "line": 1,
+              "offset": 35,
+            },
+            "start": {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "spread": false,
+          "type": "listItem",
+        },
+        {
+          "attributes": {
+            "attr2": "value2",
+          },
+          "checked": true,
+          "children": [
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 22,
+                      "line": 2,
+                      "offset": 57,
+                    },
+                    "start": {
+                      "column": 7,
+                      "line": 2,
+                      "offset": 42,
+                    },
+                  },
+                  "type": "text",
+                  "value": "Task list item",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 38,
+                  "line": 2,
+                  "offset": 73,
+                },
+                "start": {
+                  "column": 7,
+                  "line": 2,
+                  "offset": 42,
+                },
+              },
+              "type": "paragraph",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 38,
+              "line": 2,
+              "offset": 73,
+            },
+            "start": {
+              "column": 1,
+              "line": 2,
+              "offset": 36,
+            },
+          },
+          "spread": false,
+          "type": "listItem",
+        },
+      ],
+      "ordered": false,
+      "position": {
+        "end": {
+          "column": 38,
+          "line": 2,
+          "offset": 73,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "spread": false,
+      "start": null,
+      "type": "list",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 38,
+      "line": 2,
+      "offset": 73,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block component fold > blockquote multi-block uses wrapper 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        "attr": "value",
+      },
+      "children": [
+        {
+          "children": [
+            {
+              "position": {
+                "end": {
+                  "column": 4,
+                  "line": 2,
+                  "offset": 30,
+                },
+                "start": {
+                  "column": 3,
+                  "line": 2,
+                  "offset": 29,
+                },
+              },
+              "type": "text",
+              "value": "a",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 4,
+              "line": 2,
+              "offset": 30,
+            },
+            "start": {
+              "column": 3,
+              "line": 2,
+              "offset": 29,
+            },
+          },
+          "type": "paragraph",
+        },
+        {
+          "children": [
+            {
+              "position": {
+                "end": {
+                  "column": 4,
+                  "line": 4,
+                  "offset": 36,
+                },
+                "start": {
+                  "column": 3,
+                  "line": 4,
+                  "offset": 35,
+                },
+              },
+              "type": "text",
+              "value": "b",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 4,
+              "line": 4,
+              "offset": 36,
+            },
+            "start": {
+              "column": 3,
+              "line": 4,
+              "offset": 35,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "position": {
+        "end": {
+          "column": 4,
+          "line": 4,
+          "offset": 36,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+          "offset": 27,
+        },
+      },
+      "type": "blockquote",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 5,
+      "offset": 39,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block component fold > blockquote single-content uses natural form 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        "attr": "value",
+      },
+      "children": [
+        {
+          "children": [
+            {
+              "position": {
+                "end": {
+                  "column": 4,
+                  "line": 2,
+                  "offset": 30,
+                },
+                "start": {
+                  "column": 3,
+                  "line": 2,
+                  "offset": 29,
+                },
+              },
+              "type": "text",
+              "value": "a",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 4,
+              "line": 2,
+              "offset": 30,
+            },
+            "start": {
+              "column": 3,
+              "line": 2,
+              "offset": 29,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "position": {
+        "end": {
+          "column": 4,
+          "line": 2,
+          "offset": 30,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+          "offset": 27,
+        },
+      },
+      "type": "blockquote",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 3,
+      "offset": 33,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block component fold > no fold when tags differ 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        "attr": "value",
+      },
+      "children": [
+        {
+          "children": [
+            {
+              "checked": null,
+              "children": [
+                {
+                  "children": [
+                    {
+                      "position": {
+                        "end": {
+                          "column": 8,
+                          "line": 2,
+                          "offset": 26,
+                        },
+                        "start": {
+                          "column": 4,
+                          "line": 2,
+                          "offset": 22,
+                        },
+                      },
+                      "type": "text",
+                      "value": "item",
+                    },
+                  ],
+                  "position": {
+                    "end": {
+                      "column": 8,
+                      "line": 2,
+                      "offset": 26,
+                    },
+                    "start": {
+                      "column": 4,
+                      "line": 2,
+                      "offset": 22,
+                    },
+                  },
+                  "type": "paragraph",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 8,
+                  "line": 2,
+                  "offset": 26,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 2,
+                  "offset": 19,
+                },
+              },
+              "spread": false,
+              "type": "listItem",
+            },
+          ],
+          "ordered": true,
+          "position": {
+            "end": {
+              "column": 8,
+              "line": 2,
+              "offset": 26,
+            },
+            "start": {
+              "column": 1,
+              "line": 2,
+              "offset": 19,
+            },
+          },
+          "spread": false,
+          "start": 1,
+          "type": "list",
+        },
+      ],
+      "data": {
+        "hName": "ul",
+        "hProperties": {
+          "attr": "value",
+        },
+      },
+      "fmAttributes": {},
+      "name": "ul",
+      "position": {
+        "end": {
+          "column": 3,
+          "line": 3,
+          "offset": 29,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "containerComponent",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 3,
+      "offset": 29,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block component fold > ol 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        "attr": "value",
+      },
+      "children": [
+        {
+          "checked": null,
+          "children": [
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 10,
+                      "line": 2,
+                      "offset": 28,
+                    },
+                    "start": {
+                      "column": 4,
+                      "line": 2,
+                      "offset": 22,
+                    },
+                  },
+                  "type": "text",
+                  "value": "item 1",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 10,
+                  "line": 2,
+                  "offset": 28,
+                },
+                "start": {
+                  "column": 4,
+                  "line": 2,
+                  "offset": 22,
+                },
+              },
+              "type": "paragraph",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 10,
+              "line": 2,
+              "offset": 28,
+            },
+            "start": {
+              "column": 1,
+              "line": 2,
+              "offset": 19,
+            },
+          },
+          "spread": false,
+          "type": "listItem",
+        },
+        {
+          "checked": null,
+          "children": [
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 10,
+                      "line": 3,
+                      "offset": 38,
+                    },
+                    "start": {
+                      "column": 4,
+                      "line": 3,
+                      "offset": 32,
+                    },
+                  },
+                  "type": "text",
+                  "value": "item 2",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 10,
+                  "line": 3,
+                  "offset": 38,
+                },
+                "start": {
+                  "column": 4,
+                  "line": 3,
+                  "offset": 32,
+                },
+              },
+              "type": "paragraph",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 10,
+              "line": 3,
+              "offset": 38,
+            },
+            "start": {
+              "column": 1,
+              "line": 3,
+              "offset": 29,
+            },
+          },
+          "spread": false,
+          "type": "listItem",
+        },
+      ],
+      "ordered": true,
+      "position": {
+        "end": {
+          "column": 10,
+          "line": 3,
+          "offset": 38,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+          "offset": 19,
+        },
+      },
+      "spread": false,
+      "start": 1,
+      "type": "list",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 4,
+      "offset": 41,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block component fold > outer attributes win over inner 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        "attr": "outer",
+      },
+      "children": [
+        {
+          "checked": null,
+          "children": [
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 7,
+                      "line": 2,
+                      "offset": 25,
+                    },
+                    "start": {
+                      "column": 3,
+                      "line": 2,
+                      "offset": 21,
+                    },
+                  },
+                  "type": "text",
+                  "value": "item",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 7,
+                  "line": 2,
+                  "offset": 25,
+                },
+                "start": {
+                  "column": 3,
+                  "line": 2,
+                  "offset": 21,
+                },
+              },
+              "type": "paragraph",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 7,
+              "line": 2,
+              "offset": 25,
+            },
+            "start": {
+              "column": 1,
+              "line": 2,
+              "offset": 19,
+            },
+          },
+          "spread": false,
+          "type": "listItem",
+        },
+      ],
+      "ordered": false,
+      "position": {
+        "end": {
+          "column": 7,
+          "line": 2,
+          "offset": 25,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+          "offset": 19,
+        },
+      },
+      "spread": false,
+      "start": null,
+      "type": "list",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 3,
+      "offset": 28,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block component fold > table 1`] = `
+{
+  "children": [
+    {
+      "align": [
+        null,
+        null,
+      ],
+      "attributes": {
+        "attr": "value",
+      },
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 4,
+                      "line": 2,
+                      "offset": 25,
+                    },
+                    "start": {
+                      "column": 3,
+                      "line": 2,
+                      "offset": 24,
+                    },
+                  },
+                  "type": "text",
+                  "value": "a",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 5,
+                  "line": 2,
+                  "offset": 26,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 2,
+                  "offset": 22,
+                },
+              },
+              "type": "tableCell",
+            },
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 8,
+                      "line": 2,
+                      "offset": 29,
+                    },
+                    "start": {
+                      "column": 7,
+                      "line": 2,
+                      "offset": 28,
+                    },
+                  },
+                  "type": "text",
+                  "value": "b",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 10,
+                  "line": 2,
+                  "offset": 31,
+                },
+                "start": {
+                  "column": 5,
+                  "line": 2,
+                  "offset": 26,
+                },
+              },
+              "type": "tableCell",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 10,
+              "line": 2,
+              "offset": 31,
+            },
+            "start": {
+              "column": 1,
+              "line": 2,
+              "offset": 22,
+            },
+          },
+          "type": "tableRow",
+        },
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 4,
+                      "line": 4,
+                      "offset": 45,
+                    },
+                    "start": {
+                      "column": 3,
+                      "line": 4,
+                      "offset": 44,
+                    },
+                  },
+                  "type": "text",
+                  "value": "1",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 5,
+                  "line": 4,
+                  "offset": 46,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 4,
+                  "offset": 42,
+                },
+              },
+              "type": "tableCell",
+            },
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 8,
+                      "line": 4,
+                      "offset": 49,
+                    },
+                    "start": {
+                      "column": 7,
+                      "line": 4,
+                      "offset": 48,
+                    },
+                  },
+                  "type": "text",
+                  "value": "2",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 10,
+                  "line": 4,
+                  "offset": 51,
+                },
+                "start": {
+                  "column": 5,
+                  "line": 4,
+                  "offset": 46,
+                },
+              },
+              "type": "tableCell",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 10,
+              "line": 4,
+              "offset": 51,
+            },
+            "start": {
+              "column": 1,
+              "line": 4,
+              "offset": 42,
+            },
+          },
+          "type": "tableRow",
+        },
+      ],
+      "position": {
+        "end": {
+          "column": 10,
+          "line": 4,
+          "offset": 51,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+          "offset": 22,
+        },
+      },
+      "type": "table",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 5,
+      "offset": 54,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`block component fold > ul 1`] = `
+{
+  "children": [
+    {
+      "attributes": {
+        "attr": "value",
+      },
+      "children": [
+        {
+          "checked": null,
+          "children": [
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 9,
+                      "line": 2,
+                      "offset": 27,
+                    },
+                    "start": {
+                      "column": 3,
+                      "line": 2,
+                      "offset": 21,
+                    },
+                  },
+                  "type": "text",
+                  "value": "item 1",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 9,
+                  "line": 2,
+                  "offset": 27,
+                },
+                "start": {
+                  "column": 3,
+                  "line": 2,
+                  "offset": 21,
+                },
+              },
+              "type": "paragraph",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 9,
+              "line": 2,
+              "offset": 27,
+            },
+            "start": {
+              "column": 1,
+              "line": 2,
+              "offset": 19,
+            },
+          },
+          "spread": false,
+          "type": "listItem",
+        },
+        {
+          "checked": null,
+          "children": [
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 9,
+                      "line": 3,
+                      "offset": 36,
+                    },
+                    "start": {
+                      "column": 3,
+                      "line": 3,
+                      "offset": 30,
+                    },
+                  },
+                  "type": "text",
+                  "value": "item 2",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 9,
+                  "line": 3,
+                  "offset": 36,
+                },
+                "start": {
+                  "column": 3,
+                  "line": 3,
+                  "offset": 30,
+                },
+              },
+              "type": "paragraph",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 9,
+              "line": 3,
+              "offset": 36,
+            },
+            "start": {
+              "column": 1,
+              "line": 3,
+              "offset": 28,
+            },
+          },
+          "spread": false,
+          "type": "listItem",
+        },
+      ],
+      "ordered": false,
+      "position": {
+        "end": {
+          "column": 9,
+          "line": 3,
+          "offset": 36,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+          "offset": 19,
+        },
+      },
+      "spread": false,
+      "start": null,
+      "type": "list",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 3,
+      "line": 4,
+      "offset": 39,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;

--- a/test/block-attributes.test.ts
+++ b/test/block-attributes.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect } from 'vitest'
+import { runMarkdownTests } from './utils'
+
+describe('block attributes', () => {
+  runMarkdownTests({
+    'paragraph': {
+      markdown: 'A paragraph {attr="value"}',
+      extra(_md, ast) {
+        expect(ast.children[0].type).toBe('paragraph')
+        expect(ast.children[0].attributes).toEqual({ attr: 'value' })
+      },
+    },
+    'heading h1': {
+      markdown: '# h1 {attr="value"}',
+      extra(_md, ast) {
+        expect(ast.children[0].type).toBe('heading')
+        expect(ast.children[0].depth).toBe(1)
+        expect(ast.children[0].attributes).toEqual({ attr: 'value' })
+      },
+    },
+    'heading h6': {
+      markdown: '###### h6 {attr="value"}',
+      extra(_md, ast) {
+        expect(ast.children[0].depth).toBe(6)
+        expect(ast.children[0].attributes).toEqual({ attr: 'value' })
+      },
+    },
+    'bullet list items': {
+      markdown: '- a list item {attr="value"}\n- another list item {attr2="value2"}',
+      extra(_md, ast) {
+        const [first, second] = ast.children[0].children
+        // attributes attach to the list item, not the inner paragraph
+        expect(first.type).toBe('listItem')
+        expect(first.attributes).toEqual({ attr: 'value' })
+        expect(first.children[0].attributes).toBeUndefined()
+        expect(second.attributes).toEqual({ attr2: 'value2' })
+      },
+    },
+    'ordered list item': {
+      markdown: '1. List item {attr="value"}',
+      extra(_md, ast) {
+        expect(ast.children[0].ordered).toBe(true)
+        expect(ast.children[0].children[0].attributes).toEqual({ attr: 'value' })
+      },
+    },
+    'task list items': {
+      markdown: '- [ ] Task list item {attr="value"}\n- [x] Task list item {attr2="value2"}',
+      extra(_md, ast) {
+        const [first, second] = ast.children[0].children
+        expect(first.checked).toBe(false)
+        expect(first.attributes).toEqual({ attr: 'value' })
+        expect(second.checked).toBe(true)
+        expect(second.attributes).toEqual({ attr2: 'value2' })
+      },
+    },
+    'blockquote': {
+      markdown: '> Blockquote {attr="value"}',
+      extra(_md, ast) {
+        expect(ast.children[0].type).toBe('blockquote')
+        // single-content blockquote attaches to its paragraph
+        expect(ast.children[0].children[0].attributes).toEqual({ attr: 'value' })
+      },
+    },
+    'blockquote multiple paragraphs': {
+      markdown: '> Para 1 {attr="value"}\n>\n> Para 2 {attr2="value2"}',
+      extra(_md, ast) {
+        const [p1, p2] = ast.children[0].children
+        expect(p1.attributes).toEqual({ attr: 'value' })
+        expect(p2.attributes).toEqual({ attr2: 'value2' })
+      },
+    },
+    'keeps attaching to inline element': {
+      // `{attr}` directly after an inline element stays on that element
+      markdown: '**bold**{attr="value"} and more',
+      extra(_md, ast) {
+        const strong = ast.children[0].children[0]
+        expect(strong.type).toBe('strong')
+        expect(strong.attributes).toEqual({ attr: 'value' })
+        expect(ast.children[0].attributes).toBeUndefined()
+      },
+    },
+    'non-trailing attributes stay literal': {
+      markdown: 'A {x} paragraph',
+      extra(_md, ast) {
+        expect(ast.children[0].children).toHaveLength(1)
+        expect(ast.children[0].children[0]).toMatchObject({ type: 'text', value: 'A {x} paragraph' })
+        expect(ast.children[0].attributes).toBeUndefined()
+      },
+    },
+    'lifts attributes onto unwrapped container': {
+      markdown: '::test\nHello {attr="value"}\n::',
+      mdcOptions: { autoUnwrap: true },
+      removeFmAttributes: true,
+      expected: '::test{attr="value"}\nHello\n::',
+      extra(_md, ast) {
+        expect(ast.children[0].type).toBe('containerComponent')
+        expect(ast.children[0].attributes).toEqual({ attr: 'value' })
+      },
+    },
+  })
+})
+
+describe('block component fold', () => {
+  runMarkdownTests({
+    'ul': {
+      markdown: '::ul{attr="value"}\n- item 1\n- item 2\n::',
+      extra(_md, ast) {
+        const list = ast.children[0]
+        expect(list.type).toBe('list')
+        expect(list.ordered).toBe(false)
+        expect(list.attributes).toEqual({ attr: 'value' })
+        expect(list.children).toHaveLength(2)
+        expect(list.children[0].type).toBe('listItem')
+      },
+    },
+    'ol': {
+      markdown: '::ol{attr="value"}\n1. item 1\n2. item 2\n::',
+      extra(_md, ast) {
+        const list = ast.children[0]
+        expect(list.type).toBe('list')
+        expect(list.ordered).toBe(true)
+        expect(list.attributes).toEqual({ attr: 'value' })
+      },
+    },
+    'table': {
+      markdown: '::table{attr="value"}\n| a | b |\n| - | - |\n| 1 | 2 |\n::',
+      expected: [
+        '::table{attr="value"}',
+        '| a | b |',
+        '| - | - |',
+        '| 1 | 2 |',
+        '::',
+      ].join('\n'),
+      extra(_md, ast) {
+        const table = ast.children[0]
+        expect(table.type).toBe('table')
+        expect(table.attributes).toEqual({ attr: 'value' })
+      },
+    },
+    'blockquote multi-block uses wrapper': {
+      markdown: '::blockquote{attr="value"}\n> a\n>\n> b\n::',
+      extra(_md, ast) {
+        const blockquote = ast.children[0]
+        expect(blockquote.type).toBe('blockquote')
+        expect(blockquote.attributes).toEqual({ attr: 'value' })
+        expect(blockquote.children).toHaveLength(2)
+      },
+    },
+    'blockquote single-content uses natural form': {
+      markdown: '::blockquote{attr="value"}\n> a\n::',
+      // a single-content blockquote round-trips to the natural `> text {attr}`
+      expected: '> a {attr="value"}',
+      extra(_md, ast) {
+        const blockquote = ast.children[0]
+        expect(blockquote.type).toBe('blockquote')
+        expect(blockquote.attributes).toEqual({ attr: 'value' })
+        expect(blockquote.children).toHaveLength(1)
+      },
+    },
+    'outer attributes win over inner': {
+      markdown: '::ul{attr="outer"}\n- item\n::',
+      extra(_md, ast) {
+        expect(ast.children[0].attributes).toEqual({ attr: 'outer' })
+      },
+    },
+    'no fold when tags differ': {
+      // `::ul` wrapping an ordered list is not folded
+      markdown: '::ul{attr="value"}\n1. item\n::',
+      extra(_md, ast) {
+        expect(ast.children[0].type).toBe('containerComponent')
+        expect(ast.children[0].name).toBe('ul')
+        expect(ast.children[0].children[0].type).toBe('list')
+        expect(ast.children[0].children[0].ordered).toBe(true)
+      },
+    },
+  })
+})


### PR DESCRIPTION
## Summary

Two related improvements to block-level attribute handling.

**1. Attach a trailing `{attr}` to the nearest block element.** A `{attr="value"}` at the end of a line now attaches to the enclosing block — paragraphs, headings (h1–h6), bullet/ordered/task list items, and blockquote paragraphs:

```md
A paragraph {style="color: red"}

## Sample Markdown Title {#id}

- a list item {.highlight}
- [x] a task {data-done}

> A note {.note}
```

The attributes only lift to the block when they sit at the very end of the line, so `A {x} paragraph` stays literal and `**bold**{.x}` keeps targeting the `<strong>`. List-item attributes attach to the `listItem`, not its inner paragraph. Auto-unwrap lifts an unwrapped paragraph's attributes onto its container (container wins).

**2. Fold `::ul` / `::ol` / `::table` / `::blockquote` into their single same-tag child.** These elements have no native trailing-attribute syntax, so the matching block component is now a first-class way to attach attributes to them. When the wrapper contains exactly one same-tagged child, it folds into that element and applies its attributes directly (outer attrs win), instead of producing a nested duplicate:

```md
::ul{.menu}
- item 1
- item 2
::
```

parses to a `list` carrying `{.menu}` and round-trips back to the `::ul{…}` form. Same for `::ol`, `::table`, and multi-paragraph `::blockquote`; single-content blockquotes round-trip to the natural `> text {attr}` form.

Implementation spans the attribute tokenizer (accept trailing `{` after text), `from-markdown` (block attachment, unwrap lift, AST fold), and `to-markdown` (suffix + wrapper serialization, composing with gfm's `table`/`listItem` serializers rather than clobbering them).

Closes #122